### PR TITLE
Handle case where channel is not found

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,10 @@
+Version 0.4.0     unreleased
+
+	* Handle case where channel is not found.
+
 Version 0.3.1     17 Apr 2021
 
-	* Minor fixes to documentation at PyPI and readhthedocs.io.
+	* Minor fixes to documentation at PyPI and readthedocs.io.
 
 Version 0.3.0     17 Apr 2021
 


### PR DESCRIPTION
This is an update based on live testing with the new `#hcoop` channel on Libera.Chat.  If you're chatting with the bot directly (not in a channel) then some of the code fails because the "channel" is set to the bot name, but that channel doesn't really exist.  The solution is to check for existence of the channel first.