### PR TITLE
Add config option controlling whether to set channel topic

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 0.4.0     unreleased
 
 	* Handle case where channel is not found.
+	* Add config option controlling whether to set channel topic.
 
 Version 0.3.1     17 Apr 2021
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -187,32 +187,40 @@ Next, add configuration.  Create a file ``HcoopMeetbot.conf`` in the ``conf`` di
 
 If you skip this step and don't create a config file, the plugin will try to use sensible defaults as shown below.
 
-+---------------+----------------------------------------+----------------------------------------------------------------------+
-| Parameter     | Default Value                          | Description                                                          |
-+===============+========================================+======================================================================+
-| ``logDir``    | ``$HOME/hcoop-meetbot``                | Absolute path where meeting logs will be written on disk.            |
-+---------------+----------------------------------------+----------------------------------------------------------------------+
-| ``urlPrefix`` | ``/``                                  | URL prefix to place on generated links to logfiles that are reported |
-|               |                                        | when the meeting ends.  This can be a simple path, but it is more    |
-|               |                                        | useful if you set it to the base URL where the files will be served  |
-|               |                                        | from, so participants see the entire public URL.                     |
-+---------------+----------------------------------------+----------------------------------------------------------------------+
-| ``pattern``   | ``%Y/{name}.%Y%m%d.%H%M``              | Pattern for files generated in ``logDir``. The following variables   |
-|               |                                        | may be used to substitute in attributes of the meeting: ``{id}``     |
-|               |                                        | ``{name}``, ``{channel}``, ``{network}``, and ``{founder}``.         |
-|               |                                        | Additionally, you may use strftime_ codes for date fields from the   |
-|               |                                        | meeting start date. *Unlike* with the original MeetBot, you do *not* |
-|               |                                        | need to double the ``%`` characters.  The meeting name defaults to   |
-|               |                                        | the channel.  Anywhere in the path, only ``./a-zA-Z0-9_-`` are       |
-|               |                                        | allowed, and any other character will be replaced with ``_``.  You   |
-|               |                                        | may imply a subdirectory by using the ``/`` character as a path      |
-|               |                                        | separator, but directory traversal is not allowed, and the resulting |
-|               |                                        | file must be within ``logDir``.                                      |
-+---------------+----------------------------------------+----------------------------------------------------------------------+
-| ``timezone``  | ``UTC``                                | The timezone to use for files names and in generated content.        |
-|               |                                        | May be any standard IANA_ value, like ``UTC``, ``US/Eastern``,       |
-|               |                                        | or ``America/Chicago``, etc.                                         |
-+---------------+----------------------------------------+----------------------------------------------------------------------+
++---------------------+---------------------------+------------------------------------------------------------------------+
+| Parameter           | Default Value             | Description                                                            |
++=====================+===========================+========================================================================+
+| ``logDir``          | ``$HOME/hcoop-meetbot``   | Absolute path where meeting logs will be written on disk.              |
++---------------------+---------------------------+------------------------------------------------------------------------+
+| ``urlPrefix``       | ``/``                     | URL prefix to place on generated links to logfiles that are reported   |
+|                     |                           | when the meeting ends.  This can be a simple path, but it is more      |
+|                     |                           | useful if you set it to the base URL where the files will be served    |
+|                     |                           | from, so participants see the entire public URL.                       |
++---------------------+---------------------------+------------------------------------------------------------------------+
+| ``pattern``         | ``%Y/{name}.%Y%m%d.%H%M`` | Pattern for files generated in ``logDir``. The following variables     |
+|                     |                           | may be used to substitute in attributes of the meeting: ``{id}``       |
+|                     |                           | ``{name}``, ``{channel}``, ``{network}``, and ``{founder}``.           |
+|                     |                           | Additionally, you may use strftime_ codes for date fields from the     |
+|                     |                           | meeting start date. *Unlike* with the original MeetBot, you do *not*   |
+|                     |                           | need to double the ``%`` characters.  The meeting name defaults to     |
+|                     |                           | the channel.  Anywhere in the path, only ``./a-zA-Z0-9_-`` are         |
+|                     |                           | allowed, and any other character will be replaced with ``_``.  You     |
+|                     |                           | may imply a subdirectory by using the ``/`` character as a path        |
+|                     |                           | separator, but directory traversal is not allowed, and the resulting   |
+|                     |                           | file must be within ``logDir``.                                        |
++---------------------+---------------------------+------------------------------------------------------------------------+
+| ``timezone``        | ``UTC``                   | The timezone to use for files names and in generated content.          |
+|                     |                           | May be any standard IANA_ value, like ``UTC``, ``US/Eastern``,         |
+|                     |                           | or ``America/Chicago``, etc.                                           |
++---------------------+---------------------------+------------------------------------------------------------------------+
+| ``useChannelTopic`` | ``False``                 | Whether the bot should use the channel topic. If set to ``True``,      |
+|                     |                           | the bot will attempt to change the channel topic when the meeting      |
+|                     |                           | starts, when it ends, and whenever the ``#topic`` command is used.     |
+|                     |                           | This often fails with an error like ``You're not a channel operator``, |
+|                     |                           | shown in the Limnoria logs.  However, if you know your bot does have   |
+|                     |                           | permissions to set the channel topic, then can set this to ``True``    | 
+|                     |                           | and the topic will be updated to reflect the state of the meeting.     |
++---------------------+---------------------------+------------------------------------------------------------------------+
 
 Run the Bot
 ~~~~~~~~~~~
@@ -275,4 +283,5 @@ The administrator who owns the Limnoria bot has access to some additional featur
 .. _getting-started: https://docs.limnoria.net/use/getting_started.html
 .. _strftime: https://docs.python.org/3/library/datetime.html#strftime-strptime-behavior
 .. _IANA: https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+
 

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -20,11 +20,13 @@ LOG_DIR_KEY = "logDir"
 URL_PREFIX_KEY = "urlPrefix"
 PATTERN_KEY = "pattern"
 TIMEZONE_KEY = "timezone"
+USE_CHANNEL_TOPIC_KEY = "useChannelTopic"
 
 LOG_DIR_DEFAULT = os.path.join(Path.home(), "hcoop-meetbot")
 URL_PREFIX_DEFAULT = "/"
 PATTERN_DEFAULT = "%Y/{name}.%Y%m%d.%H%M"
 TIMEZONE_DEFAULT = "UTC"
+USE_CHANNEL_TOPIC_DEFAULT = False
 
 
 @attr.s(frozen=True)
@@ -38,6 +40,7 @@ class Config:
         url_prefix(str): URL prefix to place on generated links to logfiles
         pattern(str): Pattern for files generated in logFileDir
         timezone(str): Timezone string, any value valid for pytz
+        use_channel_topic(bool): Whether the bot should attempt to use the channel topic
     """
 
     conf_file = attr.ib(type=Optional[str])
@@ -45,6 +48,7 @@ class Config:
     url_prefix = attr.ib(type=str, default=URL_PREFIX_DEFAULT)
     pattern = attr.ib(type=str, default=PATTERN_DEFAULT)
     timezone = attr.ib(type=str, default=TIMEZONE_DEFAULT)
+    use_channel_topic = attr.ib(type=bool, default=USE_CHANNEL_TOPIC_DEFAULT)
 
 
 def load_config(logger: Logger, conf_dir: str) -> Config:
@@ -71,6 +75,7 @@ def load_config(logger: Logger, conf_dir: str) -> Config:
                 url_prefix=parser.get(CONF_SECTION, URL_PREFIX_KEY, fallback=URL_PREFIX_DEFAULT),
                 pattern=parser.get(CONF_SECTION, PATTERN_KEY, fallback=PATTERN_DEFAULT),
                 timezone=parser.get(CONF_SECTION, TIMEZONE_KEY, fallback=TIMEZONE_DEFAULT),
+                use_channel_topic=parser.getboolean(CONF_SECTION, USE_CHANNEL_TOPIC_KEY, fallback=USE_CHANNEL_TOPIC_DEFAULT),
             )
         except Exception:  # pylint: disable=broad-except:
             logger.exception("Failed to parse %s; using defaults", conf_file)

--- a/tests/fixtures/test_config/nochannel/HcoopMeetbot.conf
+++ b/tests/fixtures/test_config/nochannel/HcoopMeetbot.conf
@@ -3,4 +3,3 @@ logDir = /tmp/meetings
 urlPrefix = https://whatever/meetings
 pattern = {name}-%Y%m%d
 timezone = America/Chicago
-useChannelTopic = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,6 +11,7 @@ from hcoopmeetbotlogic.config import Config, load_config
 
 MISSING_DIR = "bogus"
 VALID_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/valid")
+NO_CHANNEL_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/nochannel")
 EMPTY_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/empty")
 INVALID_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/invalid")
 
@@ -24,12 +25,13 @@ def context():
 
 class TestConfig:
     def test_constructor(self):
-        config = Config("conf_file", "log_dir", "url_prefix", "pattern", "timezone")
+        config = Config("conf_file", "log_dir", "url_prefix", "pattern", "timezone", True)
         assert config.conf_file == "conf_file"
         assert config.log_dir == "log_dir"
         assert config.url_prefix == "url_prefix"
         assert config.pattern == "pattern"
         assert config.timezone == "timezone"
+        assert config.use_channel_topic is True
 
 
 class TestParsing:
@@ -42,6 +44,18 @@ class TestParsing:
         assert config.url_prefix == "https://whatever/meetings"
         assert config.pattern == "{name}-%Y%m%d"
         assert config.timezone == "America/Chicago"
+        assert config.use_channel_topic is True
+
+    def test_no_channel_configuration(self):
+        logger = MagicMock()
+        conf_dir = NO_CHANNEL_DIR
+        config = load_config(logger, conf_dir)
+        assert config.conf_file == os.path.join(NO_CHANNEL_DIR, "HcoopMeetbot.conf")
+        assert config.log_dir == "/tmp/meetings"
+        assert config.url_prefix == "https://whatever/meetings"
+        assert config.pattern == "{name}-%Y%m%d"
+        assert config.timezone == "America/Chicago"
+        assert config.use_channel_topic is False
 
     def test_empty_configuration(self):
         logger = MagicMock()
@@ -52,6 +66,7 @@ class TestParsing:
         assert config.url_prefix == "/"
         assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"
         assert config.timezone == "UTC"
+        assert config.use_channel_topic is False
 
     def test_invalid_configuration(self):
         logger = MagicMock()
@@ -62,6 +77,7 @@ class TestParsing:
         assert config.url_prefix == "/"
         assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"
         assert config.timezone == "UTC"
+        assert config.use_channel_topic is False
 
     def test_missing_configuration(self):
         logger = MagicMock()


### PR DESCRIPTION
This is based on live testing with `#hcoop` at Libera.Chat.  By default, most bots probably are not going to be channel operators.  In that case, they probably can't set the channel topic.  So, I'm making that optional.  By default, the bot won't try to set the channel topic.  If the user wants, they can enable that behavior.