### PR TITLE
Adjust rendering of attendees in minutes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 0.4.2     unreleased
 
 	* Remove the Safety scanner from the pre-commit hooks and GitHub action.
+	* Adjust rendering of attendees in minutes (closes: #15).
 
 Version 0.4.1     15 Nov 2021
 

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -59,7 +59,7 @@ ol.decimal {
         <h3>Attendees</h3>
         <ol class="decimal">
             <li py:for="attendee in minutes.attendees">
-                ${attendee.nick}<span py:if="attendee.alias"> (aka ${attendee.alias})</span> - ${attendee.count} lines
+                ${attendee.nick}<span py:if="attendee.alias"> (aka ${attendee.alias})</span> - ${attendee.count} lines (${attendee.percentage}%)
             </li>
         </ol>
 

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -56,6 +56,13 @@ ol.decimal {
     <div>
         <span class="details">Meeting started by ${minutes.founder} at ${minutes.start_time} (<a href="${logpath}">full logs</a>).</span>
 
+        <h3>Attendees</h3>
+        <ol class="decimal">
+            <li py:for="attendee in minutes.attendees">
+                ${attendee.nick}<span py:if="attendee.alias"> (aka ${attendee.alias})</span> - ${attendee.count} lines
+            </li>
+        </ol>
+
         <h3>Meeting Summary</h3>
         <ol class="decimal">
             <li py:for="topic in minutes.topics">
@@ -79,13 +86,6 @@ ol.decimal {
         </ol>
 
         <span class="details">Meeting ended at ${minutes.end_time} (<a href="${logpath}">full logs</a>).</span>
-
-        <h3>Attendees</h3>
-        <ol class="decimal">
-            <li py:for="attendee in minutes.attendees">
-                ${attendee.nick}<span py:if="attendee.alias"> (aka ${attendee.alias})</span> - ${attendee.count} lines
-            </li>
-        </ol>
 
         <h3>Action Items</h3>
         <ol class="decimal">

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -51,6 +51,7 @@ _EXCLUDED = [
     EventType.TRACK_NICK,
     EventType.ADD_CHAIR,
     EventType.REMOVE_CHAIR,
+    EventType.ATTENDEE,
 ]
 
 

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -132,6 +132,7 @@ class _MeetingAttendee:
     nick = attr.ib(type=str)
     alias = attr.ib(type=Optional[str])
     count = attr.ib(type=int)
+    percentage = attr.ib(type=str)  # stored as a string so we control rounding and format
     actions = attr.ib(type=List[str])
 
 
@@ -191,11 +192,13 @@ class _MeetingMinutes:
     @staticmethod
     def _attendees(meeting: Meeting) -> List[_MeetingAttendee]:
         attendees = []
+        total = sum(meeting.nicks.values())
         for nick in sorted(meeting.nicks.keys()):
             count = meeting.nicks[nick]
+            percentage = "%d" % (round(count / total * 100.0) if total > 0.0 else 0.0)
             alias = meeting.aliases[nick] if nick in meeting.aliases else None
             actions = _MeetingMinutes._attendee_actions(meeting, nick, alias)
-            attendee = _MeetingAttendee(nick=nick, alias=alias, count=count, actions=actions)
+            attendee = _MeetingAttendee(nick=nick, alias=alias, count=count, percentage=percentage, actions=actions)
             attendees.append(attendee)
         return attendees
 

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -46,6 +46,20 @@ ol.decimal {
     <h1>#hcoop Minutes</h1>
     <div>
         <span class="details">Meeting started by pronovic at 2021-04-12 21:06:12-0500 (<a href="log.html">full logs</a>).</span>
+        <h3>Attendees</h3>
+        <ol class="decimal">
+            <li>
+                bhkl - 3 lines
+            </li><li>
+                keverets - 1 lines
+            </li><li>
+                layline - 36 lines
+            </li><li>
+                pronovic<span> (aka Pronovic)</span> - 22 lines
+            </li><li>
+                unknown_lamer<span> (aka Clinton Alias)</span> - 17 lines
+            </li>
+        </ol>
         <h3>Meeting Summary</h3>
         <ol class="decimal">
             <li>
@@ -141,20 +155,6 @@ ol.decimal {
             </li>
         </ol>
         <span class="details">Meeting ended at 2021-04-12 21:15:39-0500 (<a href="log.html">full logs</a>).</span>
-        <h3>Attendees</h3>
-        <ol class="decimal">
-            <li>
-                bhkl - 3 lines
-            </li><li>
-                keverets - 1 lines
-            </li><li>
-                layline - 36 lines
-            </li><li>
-                pronovic<span> (aka Pronovic)</span> - 22 lines
-            </li><li>
-                unknown_lamer<span> (aka Clinton Alias)</span> - 17 lines
-            </li>
-        </ol>
         <h3>Action Items</h3>
         <ol class="decimal">
             <li>clinton alias will work with layline on this

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -49,15 +49,15 @@ ol.decimal {
         <h3>Attendees</h3>
         <ol class="decimal">
             <li>
-                bhkl - 3 lines
+                bhkl - 3 lines (4%)
             </li><li>
-                keverets - 1 lines
+                keverets - 1 lines (1%)
             </li><li>
-                layline - 36 lines
+                layline - 36 lines (46%)
             </li><li>
-                pronovic<span> (aka Pronovic)</span> - 22 lines
+                pronovic<span> (aka Pronovic)</span> - 22 lines (28%)
             </li><li>
-                unknown_lamer<span> (aka Clinton Alias)</span> - 17 lines
+                unknown_lamer<span> (aka Clinton Alias)</span> - 17 lines (22%)
             </li>
         </ol>
         <h3>Meeting Summary</h3>

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -76,23 +76,6 @@ ol.decimal {
                 <span class="topic">Attendance</span>
                 <span class="details">(<a href="log.html#id-4">pronovic</a>, 21:08:17)</span>
                 <ol class="latin">
-                    <li>
-                        <span class="event">ATTENDEE: </span>
-                                <span class="ATTENDEE">Pronovic</span>
-                        <span class="details">(<a href="log.html#id-6">pronovic</a>, 21:08:19)</span>
-                    </li><li>
-                        <span class="event">ATTENDEE: </span>
-                                <span class="ATTENDEE">Clinton Alias</span>
-                        <span class="details">(<a href="log.html#id-7">unknown_lamer</a>, 21:08:20)</span>
-                    </li><li>
-                        <span class="event">ATTENDEE: </span>
-                                <span class="ATTENDEE">keverets</span>
-                        <span class="details">(<a href="log.html#id-8">keverets</a>, 21:08:21)</span>
-                    </li><li>
-                        <span class="event">ATTENDEE: </span>
-                                <span class="ATTENDEE">layline</span>
-                        <span class="details">(<a href="log.html#id-9">layline</a>, 21:08:22)</span>
-                    </li>
                 </ol>
             </li><li>
                 <span class="topic">The first topic</span>


### PR DESCRIPTION
Changes:

1. Move **Attendees** section above the **Meeting Summary** section
1. Add a percentage along with attendee line count
1. Remove `#here` (`ATTENDEE`) events from the meeting summary (they're still in the log)

Resolves #15 