### PR TITLE
Provide deep links for actions in meeting minutes

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,6 +1,7 @@
 Version 0.4.2     unreleased
 
 	* Remove the Safety scanner from the pre-commit hooks and GitHub action.
+	* Provide deep links for actions in meeting minutes (closes: #14).
 	* Adjust rendering of attendees in minutes (closes: #15).
 
 Version 0.4.1     15 Nov 2021

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -89,7 +89,7 @@ ol.decimal {
 
         <h3>Action Items</h3>
         <ol class="decimal">
-            <li py:for="action in minutes.actions">${action}
+            <li py:for="action in minutes.actions">${action.text}
             </li>
         </ol>
 

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -101,7 +101,7 @@ ol.decimal {
                     ${attendee.nick}
                     <ol>
                         <py:for each="action in attendee.actions">
-                        <li>${action.text}</li>
+                        <li>${action.text} (<a href="#${action.id}">link</a>)</li>
                         </py:for>
                     </ol>
                 </li>

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -90,7 +90,7 @@ ol.decimal {
         <h3>Action Items</h3>
         <ol class="decimal">
             <py:for each="action in minutes.actions">
-            <li>${action.text}</li>
+            <li id="${action.id}">${action.text} (<a href="#${action.id}">link</a>)</li>
             </py:for>
         </ol>
 

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -89,8 +89,9 @@ ol.decimal {
 
         <h3>Action Items</h3>
         <ol class="decimal">
-            <li py:for="action in minutes.actions">${action.text}
-            </li>
+            <py:for each="action in minutes.actions">
+            <li>${action.text}</li>
+            </py:for>
         </ol>
 
         <h3>Action Items by Attendee</h3>

--- a/src/hcoopmeetbotlogic/templates/minutes.html
+++ b/src/hcoopmeetbotlogic/templates/minutes.html
@@ -100,7 +100,9 @@ ol.decimal {
                 <li py:if="len(attendee.actions) > 0">
                     ${attendee.nick}
                     <ol>
-                        <li py:for="action in attendee.actions">${action}</li>
+                        <py:for each="action in attendee.actions">
+                        <li>${action.text}</li>
+                        </py:for>
                     </ol>
                 </li>
             </py:for>

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -195,7 +195,7 @@ class _MeetingMinutes:
         )
 
     @staticmethod
-    def _actions(meeting: Meeting) -> List[str]:
+    def _actions(meeting: Meeting) -> List[_MeetingAction]:
         actions = []
         for event in meeting.events:
             if event.event_type == EventType.ACTION and event.operand:

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -150,6 +150,14 @@ class _MeetingEvent:
 
 
 @attr.s(frozen=True)
+class _MeetingAction:
+    """An action assigned to a meeting attendee."""
+
+    id = attr.ib(type=str)
+    text = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
 class _MeetingTopic:
     """A meeting topic within the minutes, including all of the events tied to it."""
 
@@ -171,7 +179,7 @@ class _MeetingMinutes:
     start_time = attr.ib(type=str)
     end_time = attr.ib(type=str)
     founder = attr.ib(type=str)
-    actions = attr.ib(type=List[str])
+    actions = attr.ib(type=List[_MeetingAction])
     attendees = attr.ib(type=List[_MeetingAttendee])
     topics = attr.ib(type=List[_MeetingTopic])
 
@@ -188,7 +196,12 @@ class _MeetingMinutes:
 
     @staticmethod
     def _actions(meeting: Meeting) -> List[str]:
-        return [event.operand for event in meeting.events if event.event_type == EventType.ACTION and event.operand]
+        actions = []
+        for event in meeting.events:
+            if event.event_type == EventType.ACTION and event.operand:
+                action = _MeetingAction(id="action-%s" % event.id, text=event.operand)
+                actions.append(action)
+        return actions
 
     @staticmethod
     def _attendees(meeting: Meeting) -> List[_MeetingAttendee]:

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -127,6 +127,14 @@ class _LogMessage:
 
 
 @attr.s(frozen=True)
+class _MeetingAction:
+    """An action assigned to a meeting attendee."""
+
+    id = attr.ib(type=str)
+    text = attr.ib(type=str)
+
+
+@attr.s(frozen=True)
 class _MeetingAttendee:
     """A meeting attendee, including count of chat lines and all associated actions."""
 
@@ -134,7 +142,7 @@ class _MeetingAttendee:
     alias = attr.ib(type=Optional[str])
     count = attr.ib(type=int)
     percentage = attr.ib(type=str)  # stored as a string so we control rounding and format
-    actions = attr.ib(type=List[str])
+    actions = attr.ib(type=List[_MeetingAction])
 
 
 @attr.s(frozen=True)
@@ -147,14 +155,6 @@ class _MeetingEvent:
     nick = attr.ib(type=str)
     payload = attr.ib(type=str)
     link = attr.ib(type=Optional[str], default=None)
-
-
-@attr.s(frozen=True)
-class _MeetingAction:
-    """An action assigned to a meeting attendee."""
-
-    id = attr.ib(type=str)
-    text = attr.ib(type=str)
 
 
 @attr.s(frozen=True)
@@ -217,14 +217,15 @@ class _MeetingMinutes:
         return attendees
 
     @staticmethod
-    def _attendee_actions(meeting: Meeting, nick: str, alias: Optional[str]) -> List[str]:
+    def _attendee_actions(meeting: Meeting, nick: str, alias: Optional[str]) -> List[_MeetingAction]:
         actions = []
         nick_pattern = re.compile(r"\b%s\b" % nick, re.IGNORECASE)
         alias_pattern = re.compile(r"\b%s\b" % alias, re.IGNORECASE) if alias else None
         for event in meeting.events:
             if event.event_type == EventType.ACTION and event.operand:
                 if nick_pattern.search(event.operand) or (alias_pattern and alias_pattern.search(event.operand)):
-                    actions.append(event.operand)
+                    action = _MeetingAction(id="action-%s" % event.id, text=event.operand)
+                    actions.append(action)
         return actions
 
     @staticmethod

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -140,10 +140,9 @@ ol.decimal {
         <span class="details">Meeting ended at 2021-04-12 21:15:39-0500 (<a href="log.html">full logs</a>).</span>
         <h3>Action Items</h3>
         <ol class="decimal">
-            <li>clinton alias will work with layline on this
-            </li><li>Pronovic will deal with it
-            </li><li>&lt;script&gt;alert('malicious')&lt;/script&gt;
-            </li>
+            <li>clinton alias will work with layline on this</li>
+            <li>Pronovic will deal with it</li>
+            <li>&lt;script&gt;alert('malicious')&lt;/script&gt;</li>
         </ol>
         <h3>Action Items by Attendee</h3>
         <ul>

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -149,19 +149,19 @@ ol.decimal {
                 <li>
                     layline
                     <ol>
-                        <li>clinton alias will work with layline on this</li>
+                        <li>clinton alias will work with layline on this (<a href="#action-id-18">link</a>)</li>
                     </ol>
                 </li>
                 <li>
                     pronovic
                     <ol>
-                        <li>Pronovic will deal with it</li>
+                        <li>Pronovic will deal with it (<a href="#action-id-22">link</a>)</li>
                     </ol>
                 </li>
                 <li>
                     unknown_lamer
                     <ol>
-                        <li>clinton alias will work with layline on this</li>
+                        <li>clinton alias will work with layline on this (<a href="#action-id-18">link</a>)</li>
                     </ol>
                 </li>
         </ul>

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -140,9 +140,9 @@ ol.decimal {
         <span class="details">Meeting ended at 2021-04-12 21:15:39-0500 (<a href="log.html">full logs</a>).</span>
         <h3>Action Items</h3>
         <ol class="decimal">
-            <li>clinton alias will work with layline on this</li>
-            <li>Pronovic will deal with it</li>
-            <li>&lt;script&gt;alert('malicious')&lt;/script&gt;</li>
+            <li id="action-id-18">clinton alias will work with layline on this (<a href="#action-id-18">link</a>)</li>
+            <li id="action-id-22">Pronovic will deal with it (<a href="#action-id-22">link</a>)</li>
+            <li id="action-id-24">&lt;script&gt;alert('malicious')&lt;/script&gt; (<a href="#action-id-24">link</a>)</li>
         </ol>
         <h3>Action Items by Attendee</h3>
         <ul>


### PR DESCRIPTION
This restructures the code to track an identifier for each action, so we can provide an anchor link (like `#action-id-23`) for each action.  That way, future discussions can always link back to an action in the minutes.

Resolves: #14 