### PR TITLE
Better handle nicks/aliases containing special characters

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+Version 0.5.3     unreleased
+
+	* Better handle nicks/aliases containing special characters.
+
 Version 0.5.2     13 May 2022
 
 	* Fix a bug when an IRC nick or alias includes regex special characters.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,20 +72,17 @@ You can optionally document attendance using these commands.
 | ``#here``         | Anyone | Document attendance and optionally associate an IRC nickname to an alias.  If IRC nick ``ken``     |
 |                   |        | uses ``#here``, that nick is marked as a meeting attendee in the minutes.  If IRC nick ``ken``     |
 |                   |        | includes an alias, like ``#here pronovic`` or ``#here Ken Pronovici``, then the remainder          |
-|                   |        | of the line becomes an alias for ``ken`` and can be used when assigning actions, etc.              |
+|                   |        | of the line becomes an alias for ``ken`` and can be used when assigning actions. Although          |
+|                   |        | aliases can contain whitespace (like ``Ken Pronovici`` as shown in the example above), it's        |
+|                   |        | best to avoid this.  A camel-case identifier like ``KenPronovici`` is less ambiguous.              |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
 | ``#nick``         | Chair  | Identify an IRC nickname for a user who hasn't spoken, so they can be assigned actions, like       |
 |                   |        | ``#nick whoever``.                                                                                 |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
 
-*Note:* If you use a nick or assign an alias that contains any regular
-expression special characters, it may not always be possible to identify
-actions associated with that nick.  For instance, a nick ``k[n`` generally can
-be identified, but not ``[ken`` or ``ken]``.  For the latter two, this is
-because the special character ``[`` occurs on a regular expression word
-boundary.  If a meeting participant has a nick that contains a special
-character like this, it's best to identify that participant with a simpler
-alias that can be more easily identified when parsing the IRC transcript.
+*Note:* When generating the minutes, nicks and aliases are always matched
+case-insensitively, as in IRC itself.
+
 
 Agreement and Disagrement
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -127,8 +124,9 @@ Anyone can use these commands to log important information in the minutes.
 +===================+========+====================================================================================================+
 | ``#info``         | Anyone | Log important information in the minutes, like ``#info Happy hour starts at 6pm``.                 |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
-| ``#action``       | Anyone | Document an action, like ``#action ken will pick up dinner``.  If you include a known IRC          |
-|                   |        | nickname, the action will be assigned to that user.                                                |
+| ``#action``       | Anyone | Document an action, like ``#action ken will pick up dinner`` or ``#action ken and ed own snacks``. |
+|                   |        | If you include one or more unambiguous nicks or aliases in the action text, the action will be     |
+|                   |        | assigned to those user(s). See below for some caveats.                                             |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
 | ``#idea``         | Anyone | Add an idea to the minutes, like ``#idea we should start using HCoop Meetbot``.                    |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
@@ -140,6 +138,17 @@ Anyone can use these commands to log important information in the minutes.
 |                   |        | ``#link Agenda at https://whatever/agenda.html like usual``. The URL portion of the                |
 |                   |        | message will be turned into an ``<a href>`` in the generated minutes.                              |
 +-------------------+--------+----------------------------------------------------------------------------------------------------+
+
+*Note:* When you document an action with ``#action``, the bot will try to
+identify any nick or alias associated with that action, so it can be listed in
+the **Action Items by Attendee** section of the minutes.  This works for any
+nick or alias identified with ``#here`` or ``#nick``, but *only* if the nick or
+alias can be identified *unambiguously* in the action text --- either
+surrounded by whitespace or found at the very start or end of the text.  There
+are also some special cases for common constructs like parenthesis and colons.
+To avoid confusion, it's best to make your action text as simple and as clear
+as possible. Remember that nicks and aliases are matched case-insensitively, as
+in IRC itself.
 
 Administrative Commands
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -156,11 +156,17 @@ class _AliasMatcher:
 
     @nick_pattern.default
     def _nick_pattern_default(self) -> re.Pattern:
-        return re.compile(r"(^|\s)(%s)($|\s)" % re.escape(self.nick), re.IGNORECASE)
+        return _AliasMatcher._regex(self.nick)
 
     @alias_pattern.default
     def _alias_pattern_default(self) -> Optional[re.Pattern]:
-        return re.compile(r"(^|\s)(%s)($|\s)" % re.escape(self.alias), re.IGNORECASE) if self.alias else None
+        return _AliasMatcher._regex(self.alias) if self.alias else None
+
+    @staticmethod
+    def _regex(identifier) -> re.Pattern:
+        escaped = re.escape(identifier)
+        regex = r"(^|\s)(%s|%s:|\(%s\))($|\s)" % (escaped, escaped, escaped)
+        return re.compile(regex, re.IGNORECASE)
 
     def matches(self, message: str) -> bool:
         """Return true if the attendee nick or alias is found in the message."""

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -156,11 +156,11 @@ class _AliasMatcher:
 
     @nick_pattern.default
     def _nick_pattern_default(self) -> re.Pattern:
-        return re.compile(r"\b%s\b" % re.escape(self.nick), re.IGNORECASE)
+        return re.compile(r"(^|\s)(%s)($|\s)" % re.escape(self.nick), re.IGNORECASE)
 
     @alias_pattern.default
     def _alias_pattern_default(self) -> Optional[re.Pattern]:
-        return re.compile(r"\b%s\b" % re.escape(self.alias), re.IGNORECASE) if self.alias else None
+        return re.compile(r"(^|\s)(%s)($|\s)" % re.escape(self.alias), re.IGNORECASE) if self.alias else None
 
     def matches(self, message: str) -> bool:
         """Return true if the attendee nick or alias is found in the message."""

--- a/tests/fixtures/test_writer/log.html
+++ b/tests/fixtures/test_writer/log.html
@@ -25,7 +25,7 @@ body .cmdline { font-weight: bold }
 <a name="id-3"></a><span class="tm">21:08:15</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#link </span><span class="cmdline"><span><span>Agenda at https://whatever/agenda.html like usual</span></span></span></span>
 <a name="id-4"></a><span class="tm">21:08:17</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="topic">#topic </span><span class="topicline"><span><span>Attendance</span></span></span></span>
 <a name="id-5"></a><span class="tm">21:08:18</span> <span class="nk">&lt;pronovic&gt;</span> <span><span>If you are present please write "#here $hcoop_username"</span></span>
-<a name="id-6"></a><span class="tm">21:08:19</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span><span>Pronovic</span></span></span></span>
+<a name="id-6"></a><span class="tm">21:08:19</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span><span>Pronovici</span></span></span></span>
 <a name="id-7"></a><span class="tm">21:08:20</span> <span class="nk">&lt;unknown_lamer&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span><span>Clinton Alias</span></span></span></span>
 <a name="id-8"></a><span class="tm">21:08:21</span> <span class="nk">&lt;keverets&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span><span>keverets</span></span></span></span>
 <a name="id-9"></a><span class="tm">21:08:22</span> <span class="nk">&lt;layline&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span></span></span></span>
@@ -41,7 +41,7 @@ body .cmdline { font-weight: bold }
 <a name="id-19"></a><span class="tm">21:12:59</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="topic">#topic </span><span class="topicline"><span><span>The third topic</span></span></span></span>
 <a name="id-20"></a><span class="tm">21:13:06</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#idea </span><span class="cmdline"><span><span>we should improve MeetBot</span></span></span></span>
 <a name="id-21"></a><span class="tm">21:13:27</span> <span class="nk">&lt;pronovic&gt;</span> <span><span>I'll just take this one myself</span></span>
-<a name="id-22"></a><span class="tm">21:13:41</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>Pronovic will deal with it</span></span></span></span>
+<a name="id-22"></a><span class="tm">21:13:41</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>pronovici will deal with it</span></span></span></span>
 <a name="id-23"></a><span class="tm">21:13:45</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="topic">#topic </span><span class="topicline"><span><span>Cross-site Scripting</span></span></span></span>
 <a name="id-24"></a><span class="tm">21:14:29</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>&lt;script&gt;alert('malicious')&lt;/script&gt;</span></span></span></span>
 <a name="id-25"></a><span class="tm">21:14:34</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#motion </span><span class="cmdline"><span><span>the motion</span></span></span></span>

--- a/tests/fixtures/test_writer/log.html
+++ b/tests/fixtures/test_writer/log.html
@@ -49,8 +49,8 @@ body .cmdline { font-weight: bold }
 <a name="id-27"></a><span class="tm">21:15:27</span> <span class="nk">&lt;unknown_lamer&gt;</span> <span><span class="cmd">#vote </span><span class="cmdline"><span><span>+1</span></span></span></span>
 <a name="id-28"></a><span class="tm">21:15:29</span> <span class="nk">&lt;layline&gt;</span> <span><span class="cmd">#vote </span><span class="cmdline"><span><span>-1</span></span></span></span>
 <a name="id-29"></a><span class="tm">21:15:31</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#close </span><span class="cmdline"><span></span></span></span>
-<a name="id-30"></a><span class="tm">21:15:32</span> <span class="nk">&lt;k[n&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span></span></span></span>
-<a name="id-31"></a><span class="tm">21:15:33</span> <span class="nk">&lt;unknown_lamer&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>hey k[n, your nick has regex special chars</span></span></span></span>
+<a name="id-30"></a><span class="tm">21:15:32</span> <span class="nk">&lt;pronovic&gt;</span> <span><span class="cmd">#nick </span><span class="cmdline"><span><span>k[n</span></span></span></span>
+<a name="id-31"></a><span class="tm">21:15:33</span> <span class="nk">&lt;unknown_lamer&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>hey k[n, your nick has special chars</span></span></span></span>
 <a name="id-32"></a><span class="tm">21:15:34</span> <span class="nk">&lt;ken[&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span></span></span></span>
 <a name="id-33"></a><span class="tm">21:15:35</span> <span class="nk">&lt;layline&gt;</span> <span><span class="cmd">#action </span><span class="cmdline"><span><span>ken] fix your nick!</span></span></span></span>
 <a name="id-34"></a><span class="tm">21:15:36</span> <span class="nk">&lt;[ken&gt;</span> <span><span class="cmd">#here </span><span class="cmdline"><span></span></span></span>

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -63,7 +63,7 @@ ol.decimal {
             </li><li>
                 layline - 37 lines (43%)
             </li><li>
-                pronovic<span> (aka Pronovic)</span> - 23 lines (26%)
+                pronovic<span> (aka Pronovici)</span> - 23 lines (26%)
             </li><li>
                 unknown_lamer<span> (aka Clinton Alias)</span> - 18 lines (21%)
             </li>
@@ -115,7 +115,7 @@ ol.decimal {
                         <span class="details">(<a href="log.html#id-20">pronovic</a>, 21:13:06)</span>
                     </li><li>
                         <span class="event">ACTION: </span>
-                                <span class="ACTION">Pronovic will deal with it</span>
+                                <span class="ACTION">pronovici will deal with it</span>
                         <span class="details">(<a href="log.html#id-22">pronovic</a>, 21:13:41)</span>
                     </li><li>
                         <span class="event">ACTION: </span>
@@ -165,7 +165,7 @@ ol.decimal {
         <h3>Action Items</h3>
         <ol class="decimal">
             <li id="action-id-18">clinton alias will work with layline on this (<a href="#action-id-18">link</a>)</li>
-            <li id="action-id-22">Pronovic will deal with it (<a href="#action-id-22">link</a>)</li>
+            <li id="action-id-22">pronovici will deal with it (<a href="#action-id-22">link</a>)</li>
             <li id="action-id-24">&lt;script&gt;alert('malicious')&lt;/script&gt; (<a href="#action-id-24">link</a>)</li>
             <li id="action-id-31">hey k[n, your nick has regex special characters (<a href="#action-id-31">link</a>)</li>
             <li id="action-id-33">ken] fix your nick! (<a href="#action-id-33">link</a>)</li>
@@ -175,9 +175,15 @@ ol.decimal {
         <h3>Action Items by Attendee</h3>
         <ul>
                 <li>
-                    k[n
+                    [ken
                     <ol>
-                        <li>hey k[n, your nick has regex special characters (<a href="#action-id-31">link</a>)</li>
+                        <li>not you too, [ken (<a href="#action-id-35">link</a>)</li>
+                    </ol>
+                </li>
+                <li>
+                    [m]
+                    <ol>
+                        <li>A Matrix [m] nick (<a href="#action-id-37">link</a>)</li>
                     </ol>
                 </li>
                 <li>
@@ -189,7 +195,7 @@ ol.decimal {
                 <li>
                     pronovic
                     <ol>
-                        <li>Pronovic will deal with it (<a href="#action-id-22">link</a>)</li>
+                        <li>pronovici will deal with it (<a href="#action-id-22">link</a>)</li>
                     </ol>
                 </li>
                 <li>

--- a/tests/fixtures/test_writer/minutes.html
+++ b/tests/fixtures/test_writer/minutes.html
@@ -55,15 +55,13 @@ ol.decimal {
             </li><li>
                 bhkl - 3 lines (3%)
             </li><li>
-                k[n - 1 lines (1%)
-            </li><li>
                 ken[ - 1 lines (1%)
             </li><li>
                 keverets - 2 lines (2%)
             </li><li>
                 layline - 37 lines (43%)
             </li><li>
-                pronovic<span> (aka Pronovici)</span> - 23 lines (26%)
+                pronovic<span> (aka Pronovici)</span> - 24 lines (28%)
             </li><li>
                 unknown_lamer<span> (aka Clinton Alias)</span> - 18 lines (21%)
             </li>

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -65,9 +65,9 @@ def _meeting() -> Meeting:
     tracked = meeting.track_message(message=_message(4, "pronovic", "#topic Attendance", 125))
     meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="Attendance")
     tracked = meeting.track_message(message=_message(5, "pronovic", 'If you are present please write "#here $hcoop_username"', 126))
-    tracked = meeting.track_message(message=_message(6, "pronovic", "#here Pronovic", 127))  # note: alias != nick
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Pronovic")
-    meeting.track_attendee(nick="pronovic", alias="Pronovic")
+    tracked = meeting.track_message(message=_message(6, "pronovic", "#here Pronovici", 127))  # note: alias != nick
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Pronovici")
+    meeting.track_attendee(nick="pronovic", alias="Pronovici")
     tracked = meeting.track_message(message=_message(7, "unknown_lamer", "#here Clinton Alias", 128))  # note: alias != nick
     meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Clinton Alias")
     meeting.track_attendee(nick="unknown_lamer", alias="Clinton Alias")
@@ -101,8 +101,8 @@ def _meeting() -> Meeting:
     tracked = meeting.track_message(message=_message(20, "pronovic", "#idea we should improve MeetBot", 414))
     meeting.track_event(event_type=EventType.IDEA, message=tracked, operand="we should improve MeetBot")
     tracked = meeting.track_message(message=_message(21, "pronovic", "I'll just take this one myself", 435))
-    tracked = meeting.track_message(message=_message(22, "pronovic", "#action Pronovic will deal with it", 449))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="Pronovic will deal with it")
+    tracked = meeting.track_message(message=_message(22, "pronovic", "#action pronovici will deal with it", 449))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="pronovici will deal with it")
 
     # these messages and events are associated with the final topic
     tracked = meeting.track_message(message=_message(23, "pronovic", "#topic Cross-site Scripting", 453))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -362,8 +362,15 @@ class TestAliasMatcher:
         alias_matcher = _AliasMatcher("bogus", identifier)  # checks matching for alias, since nick will never match
 
         for message in match:
-            for testcase in [message, message.upper(), message.lower(), message.title()]:  # match is not case-sensitive
+            for testcase in [message, message.upper(), message.lower(), message.title()]:  # nicks/aliases are not case-sensitive
                 if not nick_matcher.matches(testcase):
                     pytest.fail("nick '%s' not found in message '%s'" % (identifier, testcase))
                 if not alias_matcher.matches(testcase):
                     pytest.fail("alias '%s' not found in message '%s'" % (identifier, testcase))
+
+        for message in no_match:
+            for testcase in [message, message.upper(), message.lower(), message.title()]:  # nicks/aliases are not case-sensitive
+                if nick_matcher.matches(testcase):
+                    pytest.fail("nick '%s' incorrectly found in message '%s'" % (identifier, testcase))
+                if alias_matcher.matches(testcase):
+                    pytest.fail("alias '%s' incorrectly found in message '%s'" % (identifier, testcase))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -327,24 +327,36 @@ class TestAliasMatcher:
         match.append("%s got assigned a task" % identifier)
         match.append("assign that to %s please" % identifier)
         match.append("that task goes to %s" % identifier)
+        match.append("hey %s: please take care of that" % identifier)
+        match.append("an action item (%s)" % identifier)
+        match.append("(%s) an action item" % identifier)
 
         # These should NOT be considered a match because the identifier has a prefix
         no_match.append("prefix%s" % identifier)
         no_match.append("prefix%s got assigned a task" % identifier)
         no_match.append("assign that to prefix%s please" % identifier)
         no_match.append("that task goes to prefix%s" % identifier)
+        no_match.append("hey prefix%s: please take care of that" % identifier)
+        no_match.append("an action item (prefix%s)" % identifier)
+        no_match.append("(prefix%s) an action item" % identifier)
 
         # These should NOT be considered a match because the identifier has a suffix
         no_match.append("%ssuffix" % identifier)
         no_match.append("%ssuffix got assigned a task" % identifier)
         no_match.append("assign that to %ssuffix please" % identifier)
         no_match.append("that task goes to %ssuffix" % identifier)
+        no_match.append("hey %ssuffix: please take care of that" % identifier)
+        no_match.append("an action item (%ssuffix)" % identifier)
+        no_match.append("(%ssuffix) an action item" % identifier)
 
         # These should NOT be considered a match because the identifier is embedded in another string
         no_match.append("prefix%ssuffix" % identifier)
         no_match.append("prefix%ssuffix got assigned a task" % identifier)
         no_match.append("assign that to prefix%ssuffix please" % identifier)
         no_match.append("that task goes to prefix%ssuffix" % identifier)
+        no_match.append("hey prefix%ssuffix: please take care of that" % identifier)
+        no_match.append("an action item (prefix%ssuffix)" % identifier)
+        no_match.append("(prefix%ssuffix) an action item" % identifier)
 
         nick_matcher = _AliasMatcher(identifier, None)  # checks matching for nick
         alias_matcher = _AliasMatcher("bogus", identifier)  # checks matching for alias, since nick will never match

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -119,10 +119,6 @@ def _meeting() -> Meeting:
     tracked = meeting.track_message(message=_message(29, "pronovic", "#close", 559))
     meeting.track_event(event_type=EventType.ACCEPTED, message=tracked, operand="Motion accepted: 2 in favor to 1 opposed")
 
-    # There are some nicks that we will have a hard time identifying, especially ones
-    # containing non-word characters.  In this case, "k[n" does work and we can associate
-    # actions with the nick.  However, nicks that start or end with non-word characters are
-    # problematic.  We don't crash, but we also don't successfully identify their actions.
     tracked = meeting.track_message(message=_message(30, "k[n", "#here", 560))
     meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="k[n")
     meeting.track_attendee(nick="k[n", alias="k[n")

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -119,12 +119,9 @@ def _meeting() -> Meeting:
     tracked = meeting.track_message(message=_message(29, "pronovic", "#close", 559))
     meeting.track_event(event_type=EventType.ACCEPTED, message=tracked, operand="Motion accepted: 2 in favor to 1 opposed")
 
-    tracked = meeting.track_message(message=_message(30, "k[n", "#here", 560))
+    tracked = meeting.track_message(message=_message(30, "pronovic", "#nick k[n", 560))
     meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="k[n")
-    meeting.track_attendee(nick="k[n", alias="k[n")
-    tracked = meeting.track_message(
-        message=_message(31, "unknown_lamer", "#action hey k[n, your nick has regex special chars", 561)
-    )
+    tracked = meeting.track_message(message=_message(31, "unknown_lamer", "#action hey k[n, your nick has special chars", 561))
     meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="hey k[n, your nick has regex special characters")
     tracked = meeting.track_message(message=_message(32, "ken[", "#here", 562))
     meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="ke[")


### PR DESCRIPTION
In PR #21 , I fixed a bug where regex special characters in a nick caused the bot to crash.  My fix avoided the crash, but was not ideal because some kinds of nicks like `[whatever]` could not be correctly identified in `#action` commands.  This PR improves the implementation by factoring out an `_AliasMatcher` class, adding a bunch of test cases, and adjusting the regex to better match all kinds of nicks and aliases, regardless of what characters they contain.  I also clarified some of the documentation.