### PR TITLE
Generate a raw meeting log in JSON format along with HTML logs.

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -2,6 +2,7 @@ Version 0.5.3     unreleased
 
 	* Better handle nicks/aliases containing special characters.
 	* Add a suggestion at meeting start for users to identify themselves.
+	* Generate a raw meeting log in JSON format along with HTML logs.
 
 Version 0.5.2     13 May 2022
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -238,6 +238,9 @@ If you skip this step and don't create a config file, the plugin will try to use
 |                     |                           | permissions to set the channel topic, then can set this to ``True``    | 
 |                     |                           | and the topic will be updated to reflect the state of the meeting.     |
 +---------------------+---------------------------+------------------------------------------------------------------------+
+| ``outputFormat``    | ``HTML``                  | The output format to use.  Optional. Currently, the only allowed value |
+|                     |                           | is ``HTML``, but it's configurable to facilitate future enhancements.  |
++---------------------+---------------------------+------------------------------------------------------------------------+
 
 Run the Bot
 ~~~~~~~~~~~

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,7 @@ atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" a
 attrs==21.4.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 babel==2.10.1; python_version >= "3.6"
 black==22.3.0; python_full_version >= "3.6.2"
+cattrs==22.1.0; python_version >= "3.7" and python_version < "4.0"
 certifi==2021.10.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 cfgv==3.3.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 charset-normalizer==2.0.12; python_full_version >= "3.6.0" and python_version >= "3.6"
@@ -15,6 +16,7 @@ dill==0.3.4; python_full_version >= "3.6.2"
 distlib==0.3.4; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 docopt==0.6.2; python_version >= "3.5"
 docutils==0.17.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+exceptiongroup==1.0.0rc7; python_version >= "3.7" and python_version <= "3.10"
 filelock==3.6.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 genshi==0.7.7
 identify==2.5.0; python_version >= "3.7"
@@ -60,7 +62,7 @@ tomli==2.0.1; python_version < "3.11" and python_full_version >= "3.6.2" and pyt
 tox==3.25.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 typed-ast==1.5.3; python_version < "3.8" and implementation_name == "cpython" and python_full_version >= "3.6.2" and python_version >= "3.6"
 types-pytz==2021.3.7
-typing-extensions==4.2.0; python_version < "3.8" and python_full_version >= "3.6.2" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.7")
+typing-extensions==4.2.0; python_version >= "3.7" and python_version < "3.8" and python_full_version >= "3.6.2" and (python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "3.8" or python_full_version >= "3.5.0" and python_version < "3.8" and python_version >= "3.7")
 unidecode==1.3.4; python_version >= "3.6"
 urllib3==1.26.9; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 virtualenv==20.14.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"

--- a/poetry.lock
+++ b/poetry.lock
@@ -77,6 +77,19 @@ jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
 uvloop = ["uvloop (>=0.15.2)"]
 
 [[package]]
+name = "cattrs"
+version = "22.1.0"
+description = "Composable complex class support for attrs and dataclasses."
+category = "main"
+optional = false
+python-versions = ">=3.7,<4.0"
+
+[package.dependencies]
+attrs = ">=20"
+exceptiongroup = {version = "*", markers = "python_version <= \"3.10\""}
+typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
+
+[[package]]
 name = "certifi"
 version = "2021.10.8"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -184,6 +197,17 @@ description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.0rc7"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "filelock"
@@ -735,7 +759,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "4.2.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -802,7 +826,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "21fc96dc2140f74abceafc9fac9e03d54744a8153a9a0ce26a328b8c2e847866"
+content-hash = "a8d20e14d8433996713a60c2f40bf8e0d8849293488b92eadd6ae0c2c33fd19d"
 
 [metadata.files]
 alabaster = [
@@ -849,6 +873,10 @@ black = [
     {file = "black-22.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:9b542ced1ec0ceeff5b37d69838106a6348e60db7b8fdd245294dc1d26136265"},
     {file = "black-22.3.0-py3-none-any.whl", hash = "sha256:bc58025940a896d7e5356952228b68f793cf5fcb342be703c3a2669a1488cb72"},
     {file = "black-22.3.0.tar.gz", hash = "sha256:35020b8886c022ced9282b51b5a875b6d1ab0c387b31a065b84db7c33085ca79"},
+]
+cattrs = [
+    {file = "cattrs-22.1.0-py3-none-any.whl", hash = "sha256:d55c477b4672f93606e992049f15d526dc7867e6c756cd6256d4af92e2b1e364"},
+    {file = "cattrs-22.1.0.tar.gz", hash = "sha256:94b67b64cf92c994f8784c40c082177dc916e0489a73a9a36b24eb18a9db40c6"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -931,6 +959,10 @@ docopt = [
 docutils = [
     {file = "docutils-0.17.1-py2.py3-none-any.whl", hash = "sha256:cf316c8370a737a022b72b56874f6602acf974a37a9fba42ec2876387549fc61"},
     {file = "docutils-0.17.1.tar.gz", hash = "sha256:686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.0rc7-py3-none-any.whl", hash = "sha256:82dc1cfc21bb5f921a25925e80ec696c71b7d108c6c63bd8a786abe2b73c3263"},
+    {file = "exceptiongroup-1.0.0rc7.tar.gz", hash = "sha256:2019e6e9d6ef84ff65c5c7c451b75802c662d53bcb124abf47ad118d39f9a1ca"},
 ]
 filelock = [
     {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ limnoria = "^2021.01.15"
 attrs = "^21.2.0"
 pytz = "^2021.3"
 genshi = "^0.7.5"
+cattrs = "^22.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^7.1.2"

--- a/src/hcoopmeetbotlogic/command.py
+++ b/src/hcoopmeetbotlogic/command.py
@@ -70,8 +70,9 @@ class CommandDispatcher:
             self._set_channel_topic(meeting, context)
             locations = write_meeting(config=config(), meeting=meeting)
             context.send_reply("Meeting ended at %s" % self._formatdate(meeting.end_time))
-            context.send_reply("Raw log: %s" % locations.log.url)
-            context.send_reply("Minutes: %s" % locations.minutes.url)
+            context.send_reply("Raw log: %s" % locations.raw_log.url)
+            context.send_reply("Formatted log: %s" % locations.formatted_log.url)
+            context.send_reply("Minutes: %s" % locations.formatted_minutes.url)
             deactivate_meeting(meeting, retain=True)
 
     def do_save(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
@@ -80,8 +81,9 @@ class CommandDispatcher:
             meeting.track_event(EventType.SAVE_MEETING, message)
             locations = write_meeting(config=config(), meeting=meeting)
             context.send_reply("Meeting saved")
-            context.send_reply("Raw log: %s" % locations.log.url)
-            context.send_reply("Minutes: %s" % locations.minutes.url)
+            context.send_reply("Raw log: %s" % locations.raw_log.url)
+            context.send_reply("Formatted log: %s" % locations.formatted_log.url)
+            context.send_reply("Minutes: %s" % locations.formatted_minutes.url)
 
     def do_topic(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Set a new topic in the channel."""

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -31,7 +31,7 @@ TIMEZONE_DEFAULT = "UTC"
 USE_CHANNEL_TOPIC_DEFAULT = False
 
 
-class OutputFormat(Enum):
+class OutputFormat(str, Enum):
     """Legal output formats."""
 
     HTML = "HTML"

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -7,6 +7,7 @@ Plugin configuration and parsing.
 
 import configparser
 import os
+from enum import Enum
 from logging import Logger
 from pathlib import Path
 from typing import Optional
@@ -21,12 +22,22 @@ URL_PREFIX_KEY = "urlPrefix"
 PATTERN_KEY = "pattern"
 TIMEZONE_KEY = "timezone"
 USE_CHANNEL_TOPIC_KEY = "useChannelTopic"
+OUTPUT_FORMAT_KEY = "outputFormat"
 
 LOG_DIR_DEFAULT = os.path.join(Path.home(), "hcoop-meetbot")
 URL_PREFIX_DEFAULT = "/"
 PATTERN_DEFAULT = "%Y/{name}.%Y%m%d.%H%M"
 TIMEZONE_DEFAULT = "UTC"
 USE_CHANNEL_TOPIC_DEFAULT = False
+
+
+class OutputFormat(Enum):
+    """Legal output formats."""
+
+    HTML = "HTML"
+
+
+OUTPUT_FORMAT_DEFAULT = OutputFormat.HTML
 
 
 @attr.s(frozen=True)
@@ -41,6 +52,7 @@ class Config:
         pattern(str): Pattern for files generated in logFileDir
         timezone(str): Timezone string, any value valid for pytz
         use_channel_topic(bool): Whether the bot should attempt to use the channel topic
+        output_format(OutputFormat): The output format to use
     """
 
     conf_file = attr.ib(type=Optional[str])
@@ -49,6 +61,7 @@ class Config:
     pattern = attr.ib(type=str, default=PATTERN_DEFAULT)
     timezone = attr.ib(type=str, default=TIMEZONE_DEFAULT)
     use_channel_topic = attr.ib(type=bool, default=USE_CHANNEL_TOPIC_DEFAULT)
+    output_format = attr.ib(type=OutputFormat, default=OUTPUT_FORMAT_DEFAULT)
 
 
 def load_config(logger: Logger, conf_dir: str) -> Config:
@@ -76,6 +89,9 @@ def load_config(logger: Logger, conf_dir: str) -> Config:
                 pattern=parser.get(CONF_SECTION, PATTERN_KEY, fallback=PATTERN_DEFAULT),
                 timezone=parser.get(CONF_SECTION, TIMEZONE_KEY, fallback=TIMEZONE_DEFAULT),
                 use_channel_topic=parser.getboolean(CONF_SECTION, USE_CHANNEL_TOPIC_KEY, fallback=USE_CHANNEL_TOPIC_DEFAULT),
+                output_format=OutputFormat[
+                    parser.get(CONF_SECTION, OUTPUT_FORMAT_KEY, fallback=OUTPUT_FORMAT_DEFAULT.name).upper()
+                ],
             )
         except Exception:  # pylint: disable=broad-except:
             logger.exception("Failed to parse %s; using defaults", conf_file)

--- a/src/hcoopmeetbotlogic/dateutil.py
+++ b/src/hcoopmeetbotlogic/dateutil.py
@@ -2,7 +2,7 @@
 # vim: set ft=python ts=4 sw=4 expandtab:
 
 """
-Common utilities.
+Date utilities.
 """
 from datetime import datetime
 from typing import Optional

--- a/src/hcoopmeetbotlogic/jsonutil.py
+++ b/src/hcoopmeetbotlogic/jsonutil.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: set ft=python ts=4 sw=4 expandtab:
+
+"""
+JSON utilities.
+"""
+from datetime import datetime
+
+import cattr
+
+
+class CattrConverter(cattr.Converter):
+    """
+    Cattr converter that knows how to correctly serialize/deserialize datetime to an ISO 8601 timestamp.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.register_unstructure_hook(datetime, lambda datetime: datetime.isoformat() if datetime else None)  # type: ignore
+        self.register_structure_hook(datetime, lambda string, _: datetime.fromisoformat(string) if string else None)

--- a/src/hcoopmeetbotlogic/location.py
+++ b/src/hcoopmeetbotlogic/location.py
@@ -27,8 +27,9 @@ class Location:
 class Locations:
     """Locations where meeting results were written."""
 
-    log = attr.ib(type=Location)
-    minutes = attr.ib(type=Location)
+    raw_log = attr.ib(type=Location)
+    formatted_log = attr.ib(type=Location)
+    formatted_minutes = attr.ib(type=Location)
 
 
 def _file_prefix(config: Config, meeting: Meeting) -> str:
@@ -65,8 +66,10 @@ def derive_locations(config: Config, meeting: Meeting) -> Locations:
     """Derive the locations where meeting files will be written."""
     file_prefix = _file_prefix(config, meeting)
     if config.output_format == OutputFormat.HTML:
-        log = _location(config, file_prefix, ".log.html")
-        minutes = _location(config, file_prefix, ".html")
-        return Locations(log=log, minutes=minutes)
+        return Locations(
+            raw_log=_location(config, file_prefix, ".log.json"),
+            formatted_log=_location(config, file_prefix, ".log.html"),
+            formatted_minutes=_location(config, file_prefix, ".html"),
+        )
     else:
         raise ValueError("Unsupported output format: %s" % config.output_format)

--- a/src/hcoopmeetbotlogic/location.py
+++ b/src/hcoopmeetbotlogic/location.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import attr
 
-from .config import Config
+from .config import Config, OutputFormat
 from .dateutil import formatdate
 from .meeting import Meeting
 
@@ -64,6 +64,9 @@ def _location(config: Config, file_prefix: str, suffix: str) -> Location:
 def derive_locations(config: Config, meeting: Meeting) -> Locations:
     """Derive the locations where meeting files will be written."""
     file_prefix = _file_prefix(config, meeting)
-    log = _location(config, file_prefix, ".log.html")
-    minutes = _location(config, file_prefix, ".html")
-    return Locations(log=log, minutes=minutes)
+    if config.output_format == OutputFormat.HTML:
+        log = _location(config, file_prefix, ".log.html")
+        minutes = _location(config, file_prefix, ".html")
+        return Locations(log=log, minutes=minutes)
+    else:
+        raise ValueError("Unsupported output format: %s" % config.output_format)

--- a/src/hcoopmeetbotlogic/meeting.py
+++ b/src/hcoopmeetbotlogic/meeting.py
@@ -123,10 +123,21 @@ class Meeting:
     """
     A meeting on a particular IRC channel.
 
+    The meeting can be serialized and deserialized to and from JSON.  This is the mechanism we use
+    to persist the raw log to disk.  If you round trip the JSON (generate JSON and then use that
+    JSON to create a new meeting), the resulting object contains data that is equivalent, but not
+    exactly identical to, the original object.  Each tracked event has an associated message.  In
+    the original object, the tracked event always refers to one of the message objects that is
+    already in the messages list.  When you deserialize from JSON, the object in the message list
+    will be different than the one on the tracked event, although they will be equivalent by value.
+    So, if you deserialize from JSON, it's best to treat the resulting object as a read-only copy.
+    The copy won't always work exactly like a meeting that was created at runtime based on actual
+    IRC traffic.
+
     Attributes:
         id(str): Unique identifier for the meeting
         name(str): The name of the meeting, which defaults to the channel name
-        founder(str): IRC nick of the meeting founder always a member of chairs
+        founder(str): IRC nick of the meeting founder, always a member of chairs
         channel(str): Channel the meeting is running on
         network(str): Network associated with the channel
         chair(str): IRC nick of primary meeting chair, always a member of chairs

--- a/src/hcoopmeetbotlogic/meeting.py
+++ b/src/hcoopmeetbotlogic/meeting.py
@@ -5,6 +5,9 @@
 Meeting state.
 """
 
+from __future__ import annotations  # see: https://stackoverflow.com/a/33533514/2907667
+
+import json
 import uuid
 from datetime import datetime
 from enum import Enum
@@ -12,11 +15,15 @@ from typing import Any, Dict, List, Optional
 
 import attr
 
+from hcoopmeetbotlogic.jsonutil import CattrConverter
+
 from .dateutil import formatdate, now
 from .interface import Message
 
+_CONVERTER = CattrConverter()
 
-class EventType(Enum):
+
+class EventType(str, Enum):
     """Legal event types for TrackedEvent."""
 
     START_MEETING = "START_MEETING"
@@ -41,16 +48,17 @@ class EventType(Enum):
     LINK = "LINK"
 
 
-class VotingAction(Enum):
+class VotingAction(str, Enum):
     """Voting actions"""
 
     IN_FAVOR = "+1"
     OPPOSED = "-1"
 
 
+# noinspection PyUnresolvedReferences
 @attr.s(frozen=True)
 class TrackedMessage:
-    # noinspection PyUnresolvedReferences
+
     """
     A message tracked as part of a meeting.
 
@@ -73,9 +81,10 @@ class TrackedMessage:
         return "%s@%s" % (self.id, formatdate(self.timestamp))
 
 
+# noinspection PyUnresolvedReferences
 @attr.s(frozen=True)
 class TrackedEvent:
-    # noinspection PyUnresolvedReferences
+
     """
     An event tracked as part of a meeting, always tied to a specific message.
 
@@ -106,10 +115,11 @@ class TrackedEvent:
         return "%s@%s" % (self.id, formatdate(self.timestamp))
 
 
+# noinspection PyUnresolvedReferences
 # pylint: disable=too-many-instance-attributes:
 @attr.s
 class Meeting:
-    # noinspection PyUnresolvedReferences
+
     """
     A meeting on a particular IRC channel.
 
@@ -196,6 +206,15 @@ class Meeting:
     def meeting_key(channel: str, network: str) -> str:
         """Build the dict key for a network and channel."""
         return "%s/%s" % (channel, network)
+
+    def to_json(self) -> str:
+        """Serialize a meeting to JSON."""
+        return json.dumps(_CONVERTER.unstructure(self), indent="  ")
+
+    @staticmethod
+    def from_json(data: str) -> Meeting:
+        """Deserialize a meeting from JSON."""
+        return _CONVERTER.structure(json.loads(data), Meeting)
 
     def key(self) -> str:
         return Meeting.meeting_key(self.channel, self.network)

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -331,7 +331,7 @@ def write_formatted_minutes(config: Config, locations: Locations, meeting: Meeti
     context = {
         "title": "%s Minutes" % meeting.name,
         "software": {"version": VERSION, "url": URL, "date": DATE},
-        "logpath": os.path.basename(locations.formatted_minutes.path),
+        "logpath": os.path.basename(locations.formatted_log.path),
         "minutes": _MeetingMinutes.for_meeting(config, meeting),
     }
     os.makedirs(os.path.dirname(locations.formatted_minutes.path), exist_ok=True)

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -331,7 +331,7 @@ def write_formatted_minutes(config: Config, locations: Locations, meeting: Meeti
     context = {
         "title": "%s Minutes" % meeting.name,
         "software": {"version": VERSION, "url": URL, "date": DATE},
-        "logpath": os.path.basename(locations.formatted_log.path),
+        "logpath": os.path.basename(locations.formatted_minutes.path),
         "minutes": _MeetingMinutes.for_meeting(config, meeting),
     }
     os.makedirs(os.path.dirname(locations.formatted_minutes.path), exist_ok=True)

--- a/tests/fixtures/test_config/bad_boolean/HcoopMeetbot.conf
+++ b/tests/fixtures/test_config/bad_boolean/HcoopMeetbot.conf
@@ -1,0 +1,7 @@
+[HcoopMeetbot]
+logDir = /tmp/meetings
+urlPrefix = https://whatever/meetings
+pattern = {name}-%Y%m%d
+timezone = America/Chicago
+useChannelTopic = blah
+outputFormat = HTML

--- a/tests/fixtures/test_config/bad_format/HcoopMeetbot.conf
+++ b/tests/fixtures/test_config/bad_format/HcoopMeetbot.conf
@@ -1,0 +1,7 @@
+[HcoopMeetbot]
+logDir = /tmp/meetings
+urlPrefix = https://whatever/meetings
+pattern = {name}-%Y%m%d
+timezone = America/Chicago
+useChannelTopic = True
+outputFormat = BOGUS

--- a/tests/fixtures/test_config/optional/HcoopMeetbot.conf
+++ b/tests/fixtures/test_config/optional/HcoopMeetbot.conf
@@ -1,0 +1,7 @@
+[HcoopMeetbot]
+logDir = /tmp/meetings
+urlPrefix = https://whatever/meetings
+pattern = {name}-%Y%m%d
+timezone = America/Chicago
+useChannelTopic = True
+outputFormat = HTML

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -254,12 +254,15 @@ class TestCommandDispatcher:
         now.return_value = datetime(2021, 3, 7, 13, 14, 0)
         meeting.is_chair.return_value = True
         write_meeting.return_value = MagicMock()
-        write_meeting.return_value.log = MagicMock(url="logurl")
-        write_meeting.return_value.minutes = MagicMock(url="minutesurl")
+        write_meeting.return_value.raw_log = MagicMock(url="rawurl")
+        write_meeting.return_value.formatted_log = MagicMock(url="logurl")
+        write_meeting.return_value.formatted_minutes = MagicMock(url="minutesurl")
         dispatcher.do_endmeeting(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.END_MEETING, message)
         write_meeting.assert_called_once_with(config=config.return_value, meeting=meeting)
-        context.send_reply.assert_has_calls([call("Meeting ended at 11111"), call("Raw log: logurl"), call("Minutes: minutesurl")])
+        context.send_reply.assert_has_calls(
+            [call("Meeting ended at 11111"), call("Raw log: rawurl"), call("Formatted log: logurl"), call("Minutes: minutesurl")]
+        )
         context.set_topic.assert_called_once_with("original")
         formatdate.assert_called_once_with(timestamp=now.return_value, zone="America/Chicago")
         deactivate_meeting.assert_called_once_with(meeting, retain=True)
@@ -285,12 +288,15 @@ class TestCommandDispatcher:
         meeting.is_chair.return_value = True
         config.return_value = MagicMock()
         write_meeting.return_value = MagicMock()
-        write_meeting.return_value.log = MagicMock(url="logurl")
-        write_meeting.return_value.minutes = MagicMock(url="minutesurl")
+        write_meeting.return_value.raw_log = MagicMock(url="rawurl")
+        write_meeting.return_value.formatted_log = MagicMock(url="logurl")
+        write_meeting.return_value.formatted_minutes = MagicMock(url="minutesurl")
         dispatcher.do_save(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.SAVE_MEETING, message)
         write_meeting.assert_called_once_with(config=config.return_value, meeting=meeting)
-        context.send_reply.assert_has_calls([call("Meeting saved"), call("Raw log: logurl"), call("Minutes: minutesurl")])
+        context.send_reply.assert_has_calls(
+            [call("Meeting saved"), call("Raw log: rawurl"), call("Formatted log: logurl"), call("Minutes: minutesurl")]
+        )
 
     @patch("hcoopmeetbotlogic.command.write_meeting")
     def test_save_as_not_chair(self, write_meeting, dispatcher, meeting, context, message):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,13 +7,16 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from hcoopmeetbotlogic.config import Config, load_config
+from hcoopmeetbotlogic.config import Config, OutputFormat, load_config
 
 MISSING_DIR = "bogus"
-VALID_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/valid")
+VALID_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/valid")  # valid config with no optional values
+OPTIONAL_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/optional")  # valid config with optional values
 NO_CHANNEL_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/nochannel")
 EMPTY_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/empty")
 INVALID_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/invalid")
+BAD_BOOLEAN_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/bad_boolean")
+BAD_FORMAT_DIR = os.path.join(os.path.dirname(__file__), "fixtures/test_config/bad_format")
 
 
 @pytest.fixture
@@ -25,13 +28,14 @@ def context():
 
 class TestConfig:
     def test_constructor(self):
-        config = Config("conf_file", "log_dir", "url_prefix", "pattern", "timezone", True)
+        config = Config("conf_file", "log_dir", "url_prefix", "pattern", "timezone", True, OutputFormat.HTML)
         assert config.conf_file == "conf_file"
         assert config.log_dir == "log_dir"
         assert config.url_prefix == "url_prefix"
         assert config.pattern == "pattern"
         assert config.timezone == "timezone"
         assert config.use_channel_topic is True
+        assert config.output_format == OutputFormat.HTML
 
 
 class TestParsing:
@@ -45,6 +49,19 @@ class TestParsing:
         assert config.pattern == "{name}-%Y%m%d"
         assert config.timezone == "America/Chicago"
         assert config.use_channel_topic is True
+        assert config.output_format == OutputFormat.HTML
+
+    def test_valid_configuration_with_optional(self):
+        logger = MagicMock()
+        conf_dir = OPTIONAL_DIR
+        config = load_config(logger, conf_dir)
+        assert config.conf_file == os.path.join(OPTIONAL_DIR, "HcoopMeetbot.conf")
+        assert config.log_dir == "/tmp/meetings"
+        assert config.url_prefix == "https://whatever/meetings"
+        assert config.pattern == "{name}-%Y%m%d"
+        assert config.timezone == "America/Chicago"
+        assert config.use_channel_topic is True
+        assert config.output_format == OutputFormat.HTML
 
     def test_no_channel_configuration(self):
         logger = MagicMock()
@@ -62,6 +79,28 @@ class TestParsing:
         conf_dir = EMPTY_DIR
         config = load_config(logger, conf_dir)  # any key that can't be loaded gets defaults
         assert config.conf_file == os.path.join(EMPTY_DIR, "HcoopMeetbot.conf")
+        assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
+        assert config.url_prefix == "/"
+        assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"
+        assert config.timezone == "UTC"
+        assert config.use_channel_topic is False
+
+    def test_bad_boolean_configuration(self):
+        logger = MagicMock()
+        conf_dir = BAD_BOOLEAN_DIR
+        config = load_config(logger, conf_dir)  # since the boolean value is invalid, it's like the file doesn't exist
+        assert config.conf_file is None
+        assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
+        assert config.url_prefix == "/"
+        assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"
+        assert config.timezone == "UTC"
+        assert config.use_channel_topic is False
+
+    def test_bad_format_configuration(self):
+        logger = MagicMock()
+        conf_dir = BAD_FORMAT_DIR
+        config = load_config(logger, conf_dir)  # since the output format is invalid, it's like the file doesn't exist
+        assert config.conf_file is None
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
         assert config.url_prefix == "/"
         assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -39,6 +39,8 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/constant.log.json"
+        assert locations.raw_log.url == "https://whatever/constant.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/constant.log.html"
         assert locations.formatted_log.url == "https://whatever/constant.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/constant.html"
@@ -54,6 +56,8 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/i-n-f-c-n.log.json"
+        assert locations.raw_log.url == "https://whatever/i-n-f-c-n.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/i-n-f-c-n.log.html"
         assert locations.formatted_log.url == "https://whatever/i-n-f-c-n.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/i-n-f-c-n.html"
@@ -69,6 +73,8 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/20210307.1314.log.json"
+        assert locations.raw_log.url == "https://whatever/20210307.1314.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/20210307.1314.log.html"
         assert locations.formatted_log.url == "https://whatever/20210307.1314.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/20210307.1314.html"
@@ -91,6 +97,8 @@ class TestFunctions:
             start_time=datetime(2021, 3, 7, 13, 14, 0),
         )
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/_network_.log.json"
+        assert locations.raw_log.url == "https://whatever/_network_.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/_network_.log.html"
         assert locations.formatted_log.url == "https://whatever/_network_.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/_network_.html"
@@ -106,6 +114,8 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="#n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/2021/n.20210307.1314.log.json"
+        assert locations.raw_log.url == "https://whatever/2021/n.20210307.1314.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/2021/n.20210307.1314.log.html"
         assert locations.formatted_log.url == "https://whatever/2021/n.20210307.1314.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/2021/n.20210307.1314.html"
@@ -117,6 +127,8 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
+        assert locations.raw_log.path == "/data/meetings/hcoop/20210307.1314.log.json"
+        assert locations.raw_log.url == "https://whatever/20210307.1314.log.json"
         assert locations.formatted_log.path == "/data/meetings/hcoop/20210307.1314.log.html"
         assert locations.formatted_log.url == "https://whatever/20210307.1314.log.html"
         assert locations.formatted_minutes.path == "/data/meetings/hcoop/20210307.1314.html"

--- a/tests/test_location.py
+++ b/tests/test_location.py
@@ -19,11 +19,13 @@ class TestLocation:
 
 class TestLocations:
     def test_constructor(self):
-        log = Location("log-path", "log-url")
-        minutes = Location("minutes-path", "minutes-url")
-        locations = Locations(log, minutes)
-        assert locations.log is log
-        assert locations.minutes is minutes
+        raw_log = Location("raw-path", "raw-url")
+        formatted_log = Location("log-path", "log-url")
+        formatted_minutes = Location("minutes-path", "minutes-url")
+        locations = Locations(raw_log, formatted_log, formatted_minutes)
+        assert locations.raw_log is raw_log
+        assert locations.formatted_log is formatted_log
+        assert locations.formatted_minutes is formatted_minutes
 
 
 class TestFunctions:
@@ -37,10 +39,10 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/constant.log.html"
-        assert locations.log.url == "https://whatever/constant.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/constant.html"
-        assert locations.minutes.url == "https://whatever/constant.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/constant.log.html"
+        assert locations.formatted_log.url == "https://whatever/constant.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/constant.html"
+        assert locations.formatted_minutes.url == "https://whatever/constant.html"
 
     def test_derive_locations_with_subsitution_variables(self):
         config = Config(
@@ -52,10 +54,10 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/i-n-f-c-n.log.html"
-        assert locations.log.url == "https://whatever/i-n-f-c-n.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/i-n-f-c-n.html"
-        assert locations.minutes.url == "https://whatever/i-n-f-c-n.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/i-n-f-c-n.log.html"
+        assert locations.formatted_log.url == "https://whatever/i-n-f-c-n.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/i-n-f-c-n.html"
+        assert locations.formatted_minutes.url == "https://whatever/i-n-f-c-n.html"
 
     def test_derive_locations_with_date_fields(self):
         config = Config(
@@ -67,10 +69,10 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/20210307.1314.log.html"
-        assert locations.log.url == "https://whatever/20210307.1314.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/20210307.1314.html"
-        assert locations.minutes.url == "https://whatever/20210307.1314.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/20210307.1314.log.html"
+        assert locations.formatted_log.url == "https://whatever/20210307.1314.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/20210307.1314.html"
+        assert locations.formatted_minutes.url == "https://whatever/20210307.1314.html"
 
     def test_derive_locations_with_normalization(self):
         config = Config(
@@ -89,10 +91,10 @@ class TestFunctions:
             start_time=datetime(2021, 3, 7, 13, 14, 0),
         )
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/_network_.log.html"
-        assert locations.log.url == "https://whatever/_network_.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/_network_.html"
-        assert locations.minutes.url == "https://whatever/_network_.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/_network_.log.html"
+        assert locations.formatted_log.url == "https://whatever/_network_.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/_network_.html"
+        assert locations.formatted_minutes.url == "https://whatever/_network_.html"
 
     def test_derive_locations_with_multiple(self):
         config = Config(
@@ -104,10 +106,10 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="#n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/2021/n.20210307.1314.log.html"
-        assert locations.log.url == "https://whatever/2021/n.20210307.1314.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/2021/n.20210307.1314.html"
-        assert locations.minutes.url == "https://whatever/2021/n.20210307.1314.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/2021/n.20210307.1314.log.html"
+        assert locations.formatted_log.url == "https://whatever/2021/n.20210307.1314.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/2021/n.20210307.1314.html"
+        assert locations.formatted_minutes.url == "https://whatever/2021/n.20210307.1314.html"
 
     def test_derive_locations_with_attempted_path_traversal_absolute(self):
         config = Config(
@@ -115,10 +117,10 @@ class TestFunctions:
         )
         meeting = Meeting(id="i", name="n", founder="f", channel="c", network="n", start_time=datetime(2021, 3, 7, 13, 14, 0))
         locations = derive_locations(config, meeting)
-        assert locations.log.path == "/data/meetings/hcoop/20210307.1314.log.html"
-        assert locations.log.url == "https://whatever/20210307.1314.log.html"
-        assert locations.minutes.path == "/data/meetings/hcoop/20210307.1314.html"
-        assert locations.minutes.url == "https://whatever/20210307.1314.html"
+        assert locations.formatted_log.path == "/data/meetings/hcoop/20210307.1314.log.html"
+        assert locations.formatted_log.url == "https://whatever/20210307.1314.log.html"
+        assert locations.formatted_minutes.path == "/data/meetings/hcoop/20210307.1314.html"
+        assert locations.formatted_minutes.url == "https://whatever/20210307.1314.html"
 
     def test_derive_locations_with_attempted_path_traversal_relative(self):
         config = Config(

--- a/tests/test_meeting.py
+++ b/tests/test_meeting.py
@@ -9,6 +9,8 @@ from pytz import utc
 from hcoopmeetbotlogic.interface import Message
 from hcoopmeetbotlogic.meeting import EventType, Meeting, TrackedEvent, TrackedMessage
 
+from .testdata import sample_meeting
+
 
 class TestTrackedMessage:
     def test_constructor(self):
@@ -72,6 +74,12 @@ class TestMeeting:
         assert meeting.aliases == {}
         assert meeting.key() == "channel/network"
         assert meeting.active is False
+
+    def test_json_roundtrip(self):
+        left = sample_meeting()
+        serialized = left.to_json()
+        right = Meeting.from_json(serialized)
+        assert left == right
 
     def test_meeting_key(self):
         assert Meeting.meeting_key("channel", "network") == "channel/network"

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -2,150 +2,21 @@
 # vim: set ft=python ts=4 sw=4 expandtab:
 
 import os
-from datetime import datetime, timedelta
+from datetime import datetime
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from hcoopmeetbotlogic.config import OutputFormat
-from hcoopmeetbotlogic.interface import Message
 from hcoopmeetbotlogic.location import Location, Locations
-from hcoopmeetbotlogic.meeting import EventType, Meeting, VotingAction
 from hcoopmeetbotlogic.writer import _AliasMatcher, _LogMessage, write_meeting
+
+from .testdata import contents, sample_meeting
 
 EXPECTED_LOG = os.path.join(os.path.dirname(__file__), "fixtures/test_writer/log.html")
 EXPECTED_MINUTES = os.path.join(os.path.dirname(__file__), "fixtures/test_writer/minutes.html")
-
 TIMESTAMP = datetime(2021, 3, 7, 13, 14, 0)
-START_TIME = datetime(2021, 4, 13, 2, 6, 12)
-
-
-def _contents(path: str) -> str:
-    """Get contents of a file for comparison."""
-    with open(path, "r", encoding="utf-8") as out:
-        return out.read()
-
-
-def _time(seconds: int) -> datetime:
-    """Generate a timestamp relative to START_TIME"""
-    return START_TIME + timedelta(seconds=seconds)
-
-
-def _message(identifier: int, nick: str, payload: str, seconds: int) -> Message:
-    """Generate a mocked message with some values"""
-    return MagicMock(id="id-%d" % identifier, nick=nick, payload=payload, timestamp=_time(seconds))
-
-
-# pylint: disable=too-many-statements:
-def _meeting() -> Meeting:
-    """Generate a semi-realistic meeting that can be used for unit tests"""
-
-    # Initialize the meeting
-    meeting = Meeting(founder="pronovic", channel="#hcoop", network="network")
-
-    # this gets us some data in the attendees section without having to add tons of messages
-    meeting.track_nick("unknown_lamer", 13)
-    meeting.track_nick("layline", 32)
-    meeting.track_nick("bhkl", 3)
-
-    # Start the meeting
-    meeting.active = True
-    meeting.start_time = _time(0)
-    tracked = meeting.track_message(message=_message(0, "pronovic", "#startmeeting", 0))
-    meeting.track_event(event_type=EventType.START_MEETING, message=tracked)
-
-    # these messages and events will be associated with the prologue, because no topic has been set yet
-    tracked = meeting.track_message(message=_message(1, "pronovic", "Hello everyone, is it ok to get started?", 32))
-    tracked = meeting.track_message(message=_message(2, "unknown_lamer", "Yeah, let's do it", 97))
-    tracked = meeting.track_message(message=_message(3, "pronovic", "#link Agenda at https://whatever/agenda.html like usual", 123))
-    meeting.track_event(event_type=EventType.LINK, message=tracked, operand="Agenda at https://whatever/agenda.html like usual")
-
-    # these messages and events are associated with the attendance topic
-    # note that we track attendees manually since that's what would be done by the command interpreter
-    tracked = meeting.track_message(message=_message(4, "pronovic", "#topic Attendance", 125))
-    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="Attendance")
-    tracked = meeting.track_message(message=_message(5, "pronovic", 'If you are present please write "#here $hcoop_username"', 126))
-    tracked = meeting.track_message(message=_message(6, "pronovic", "#here Pronovici", 127))  # note: alias != nick
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Pronovici")
-    meeting.track_attendee(nick="pronovic", alias="Pronovici")
-    tracked = meeting.track_message(message=_message(7, "unknown_lamer", "#here Clinton Alias", 128))  # note: alias != nick
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Clinton Alias")
-    meeting.track_attendee(nick="unknown_lamer", alias="Clinton Alias")
-    tracked = meeting.track_message(message=_message(8, "keverets", "#here keverets", 129))  # note: alias == nick
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="keverets")
-    meeting.track_attendee(nick="keverets", alias="keverets")
-    tracked = meeting.track_message(message=_message(9, "layline", "#here", 130))  # note: no alias, so it's set to nick
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="layline")
-    meeting.track_attendee(nick="layline", alias="layline")
-    tracked = meeting.track_message(message=_message(10, "pronovic", "Thanks, everyone", 130))
-
-    # these messages and events are associated with the first topic
-    tracked = meeting.track_message(message=_message(11, "pronovic", "#topic The first topic", 199))
-    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The first topic")
-    tracked = meeting.track_message(message=_message(12, "pronovic", "Does anyone have any discussion?", 231))
-    tracked = meeting.track_message(message=_message(13, "layline", "Is this important?", 232))
-    tracked = meeting.track_message(message=_message(14, "unknown_lamer", "Yes it is", 299))
-    tracked = meeting.track_message(message=_message(15, "pronovic", "#info moving on then", 305))
-    meeting.track_event(event_type=EventType.INFO, message=tracked, operand="moving on then")
-
-    # these messages and events are associated with the second topic
-    tracked = meeting.track_message(message=_message(16, "pronovic", "#topic The second topic", 332))
-    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The second topic")
-    tracked = meeting.track_message(message=_message(17, "layline", "\x01unknown_lamer: I need you for this action\x01", 334))
-    tracked = meeting.track_message(message=_message(18, "pronovic", "#action clinton alias will work with layline on this", 401))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="clinton alias will work with layline on this")
-
-    # these messages and events are associated with the third topic
-    tracked = meeting.track_message(message=_message(19, "pronovic", "#topic The third topic", 407))
-    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The third topic")
-    tracked = meeting.track_message(message=_message(20, "pronovic", "#idea we should improve MeetBot", 414))
-    meeting.track_event(event_type=EventType.IDEA, message=tracked, operand="we should improve MeetBot")
-    tracked = meeting.track_message(message=_message(21, "pronovic", "I'll just take this one myself", 435))
-    tracked = meeting.track_message(message=_message(22, "pronovic", "#action pronovici will deal with it", 449))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="pronovici will deal with it")
-
-    # these messages and events are associated with the final topic
-    tracked = meeting.track_message(message=_message(23, "pronovic", "#topic Cross-site Scripting", 453))
-    tracked = meeting.track_message(message=_message(24, "pronovic", "#action <script>alert('malicious')</script>", 497))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="<script>alert('malicious')</script>")
-    tracked = meeting.track_message(message=_message(25, "pronovic", "#motion the motion", 502))
-    meeting.track_event(event_type=EventType.MOTION, message=tracked, operand="the motion")
-    tracked = meeting.track_message(message=_message(26, "pronovic", "#vote +1", 553))
-    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.IN_FAVOR)
-    tracked = meeting.track_message(message=_message(27, "unknown_lamer", "#vote +1", 555))
-    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.IN_FAVOR)
-    tracked = meeting.track_message(message=_message(28, "layline", "#vote -1", 557))
-    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.OPPOSED)
-    tracked = meeting.track_message(message=_message(29, "pronovic", "#close", 559))
-    meeting.track_event(event_type=EventType.ACCEPTED, message=tracked, operand="Motion accepted: 2 in favor to 1 opposed")
-
-    tracked = meeting.track_message(message=_message(30, "pronovic", "#nick k[n", 560))
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="k[n")
-    tracked = meeting.track_message(message=_message(31, "unknown_lamer", "#action hey k[n, your nick has special chars", 561))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="hey k[n, your nick has regex special characters")
-    tracked = meeting.track_message(message=_message(32, "ken[", "#here", 562))
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="ke[")
-    meeting.track_attendee(nick="ken[", alias="ken[")
-    tracked = meeting.track_message(message=_message(33, "layline", "#action ken] fix your nick!", 563))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="ken] fix your nick!")
-    tracked = meeting.track_message(message=_message(34, "[ken", "#here", 564))
-    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="[ken")
-    meeting.track_attendee(nick="[ken", alias="[ken")
-    tracked = meeting.track_message(message=_message(35, "pronovic", "#action not you too, [ken", 565))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="not you too, [ken")
-    tracked = meeting.track_message(message=_message(36, "[m]", "#here", 566))
-    meeting.track_attendee(nick="[m]", alias="[m]")
-    tracked = meeting.track_message(message=_message(37, "keverets", "#action A Matrix [m] nick", 567))
-    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="A Matrix [m] nick")
-
-    # End the meeting
-    tracked = meeting.track_message(message=_message(38, "pronovic", "#endmeeting", 570))
-    meeting.track_event(event_type=EventType.END_MEETING, message=tracked)
-    meeting.active = False
-    meeting.end_time = _time(570)
-
-    return meeting
 
 
 class TestLogMessage:
@@ -288,13 +159,13 @@ class TestRendering:
             locations = Locations(log=log, minutes=minutes)
             derive_locations.return_value = locations
             config = MagicMock(timezone="America/Chicago", output_format=OutputFormat.HTML)
-            meeting = _meeting()
+            meeting = sample_meeting()
             assert write_meeting(config, meeting) is locations
             # print("\n" + _contents(log.path))
             # print("\n" + _contents(minutes.path))
             derive_locations.assert_called_once_with(config, meeting)
-            assert _contents(log.path) == _contents(EXPECTED_LOG)
-            assert _contents(minutes.path) == _contents(EXPECTED_MINUTES)
+            assert contents(log.path) == contents(EXPECTED_LOG)
+            assert contents(minutes.path) == contents(EXPECTED_MINUTES)
 
 
 class TestAliasMatcher:

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from hcoopmeetbotlogic.config import OutputFormat
 from hcoopmeetbotlogic.interface import Message
 from hcoopmeetbotlogic.location import Location, Locations
 from hcoopmeetbotlogic.meeting import EventType, Meeting, VotingAction
@@ -277,16 +278,16 @@ class TestRendering:
     @patch("hcoopmeetbotlogic.writer.DATE", "2001-02-03")
     @patch("hcoopmeetbotlogic.writer.VERSION", "1.2.3")
     @patch("hcoopmeetbotlogic.writer.derive_locations")
-    def test_write_meeting_wiring(self, derive_locations):
+    def test_html_rendering(self, derive_locations):
         # The goal here is to prove that rendering is wired up properly, the templates are
         # valid, and that files are written as expected.  We don't necessarily verify every
-        # different scenario - there are other tests above that delve into some of the details.
+        # different scenario - there are tests elsewhere that delve into some of the details.
         with TemporaryDirectory() as temp:
             log = Location(path=os.path.join(temp, "log.html"), url="http://")
             minutes = Location(path=os.path.join(temp, "minutes.html"), url="http://")
             locations = Locations(log=log, minutes=minutes)
             derive_locations.return_value = locations
-            config = MagicMock(timezone="America/Chicago")
+            config = MagicMock(timezone="America/Chicago", output_format=OutputFormat.HTML)
             meeting = _meeting()
             assert write_meeting(config, meeting) is locations
             # print("\n" + _contents(log.path))

--- a/tests/test_writer.py
+++ b/tests/test_writer.py
@@ -163,8 +163,9 @@ class TestRendering:
             config = MagicMock(timezone="America/Chicago", output_format=OutputFormat.HTML)
             meeting = sample_meeting()
             assert write_meeting(config, meeting) is locations
-            # print("\n" + _contents(log.path))
-            # print("\n" + _contents(minutes.path))
+            # print("\n" + contents(raw_log.path))
+            # print("\n" + contents(formatted_log.path))
+            # print("\n" + contents(formatted_minutes.path))
             derive_locations.assert_called_once_with(config, meeting)
             assert meeting == Meeting.from_json(contents(raw_log.path))  # raw log should exactly represent the meeting input
             assert contents(formatted_log.path) == contents(EXPECTED_LOG)

--- a/tests/testdata.py
+++ b/tests/testdata.py
@@ -1,0 +1,137 @@
+# -*- coding: utf-8 -*-
+# vim: set ft=python ts=4 sw=4 expandtab:
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+from hcoopmeetbotlogic.interface import Message
+from hcoopmeetbotlogic.meeting import EventType, Meeting, VotingAction
+
+START_TIME = datetime(2021, 4, 13, 2, 6, 12)
+
+
+def contents(path: str) -> str:
+    """Get contents of a file for comparison."""
+    with open(path, "r", encoding="utf-8") as out:
+        return out.read()
+
+
+def time(seconds: int) -> datetime:
+    """Generate a timestamp relative to START_TIME"""
+    return START_TIME + timedelta(seconds=seconds)
+
+
+def message(identifier: int, nick: str, payload: str, seconds: int) -> Message:
+    """Generate a mocked message with some values"""
+    return MagicMock(id="id-%d" % identifier, nick=nick, payload=payload, timestamp=time(seconds))
+
+
+# pylint: disable=too-many-statements:
+def sample_meeting() -> Meeting:
+    """Generate a semi-realistic meeting that can be used for unit tests"""
+
+    # Initialize the meeting
+    meeting = Meeting(founder="pronovic", channel="#hcoop", network="network")
+
+    # this gets us some data in the attendees section without having to add tons of messages
+    meeting.track_nick("unknown_lamer", 13)
+    meeting.track_nick("layline", 32)
+    meeting.track_nick("bhkl", 3)
+
+    # Start the meeting
+    meeting.active = True
+    meeting.start_time = time(0)
+    tracked = meeting.track_message(message=message(0, "pronovic", "#startmeeting", 0))
+    meeting.track_event(event_type=EventType.START_MEETING, message=tracked)
+
+    # these messages and events will be associated with the prologue, because no topic has been set yet
+    tracked = meeting.track_message(message=message(1, "pronovic", "Hello everyone, is it ok to get started?", 32))
+    tracked = meeting.track_message(message=message(2, "unknown_lamer", "Yeah, let's do it", 97))
+    tracked = meeting.track_message(message=message(3, "pronovic", "#link Agenda at https://whatever/agenda.html like usual", 123))
+    meeting.track_event(event_type=EventType.LINK, message=tracked, operand="Agenda at https://whatever/agenda.html like usual")
+
+    # these messages and events are associated with the attendance topic
+    # note that we track attendees manually since that's what would be done by the command interpreter
+    tracked = meeting.track_message(message=message(4, "pronovic", "#topic Attendance", 125))
+    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="Attendance")
+    tracked = meeting.track_message(message=message(5, "pronovic", 'If you are present please write "#here $hcoop_username"', 126))
+    tracked = meeting.track_message(message=message(6, "pronovic", "#here Pronovici", 127))  # note: alias != nick
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Pronovici")
+    meeting.track_attendee(nick="pronovic", alias="Pronovici")
+    tracked = meeting.track_message(message=message(7, "unknown_lamer", "#here Clinton Alias", 128))  # note: alias != nick
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="Clinton Alias")
+    meeting.track_attendee(nick="unknown_lamer", alias="Clinton Alias")
+    tracked = meeting.track_message(message=message(8, "keverets", "#here keverets", 129))  # note: alias == nick
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="keverets")
+    meeting.track_attendee(nick="keverets", alias="keverets")
+    tracked = meeting.track_message(message=message(9, "layline", "#here", 130))  # note: no alias, so it's set to nick
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="layline")
+    meeting.track_attendee(nick="layline", alias="layline")
+    tracked = meeting.track_message(message=message(10, "pronovic", "Thanks, everyone", 130))
+
+    # these messages and events are associated with the first topic
+    tracked = meeting.track_message(message=message(11, "pronovic", "#topic The first topic", 199))
+    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The first topic")
+    tracked = meeting.track_message(message=message(12, "pronovic", "Does anyone have any discussion?", 231))
+    tracked = meeting.track_message(message=message(13, "layline", "Is this important?", 232))
+    tracked = meeting.track_message(message=message(14, "unknown_lamer", "Yes it is", 299))
+    tracked = meeting.track_message(message=message(15, "pronovic", "#info moving on then", 305))
+    meeting.track_event(event_type=EventType.INFO, message=tracked, operand="moving on then")
+
+    # these messages and events are associated with the second topic
+    tracked = meeting.track_message(message=message(16, "pronovic", "#topic The second topic", 332))
+    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The second topic")
+    tracked = meeting.track_message(message=message(17, "layline", "\x01unknown_lamer: I need you for this action\x01", 334))
+    tracked = meeting.track_message(message=message(18, "pronovic", "#action clinton alias will work with layline on this", 401))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="clinton alias will work with layline on this")
+
+    # these messages and events are associated with the third topic
+    tracked = meeting.track_message(message=message(19, "pronovic", "#topic The third topic", 407))
+    meeting.track_event(event_type=EventType.TOPIC, message=tracked, operand="The third topic")
+    tracked = meeting.track_message(message=message(20, "pronovic", "#idea we should improve MeetBot", 414))
+    meeting.track_event(event_type=EventType.IDEA, message=tracked, operand="we should improve MeetBot")
+    tracked = meeting.track_message(message=message(21, "pronovic", "I'll just take this one myself", 435))
+    tracked = meeting.track_message(message=message(22, "pronovic", "#action pronovici will deal with it", 449))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="pronovici will deal with it")
+
+    # these messages and events are associated with the final topic
+    tracked = meeting.track_message(message=message(23, "pronovic", "#topic Cross-site Scripting", 453))
+    tracked = meeting.track_message(message=message(24, "pronovic", "#action <script>alert('malicious')</script>", 497))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="<script>alert('malicious')</script>")
+    tracked = meeting.track_message(message=message(25, "pronovic", "#motion the motion", 502))
+    meeting.track_event(event_type=EventType.MOTION, message=tracked, operand="the motion")
+    tracked = meeting.track_message(message=message(26, "pronovic", "#vote +1", 553))
+    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.IN_FAVOR)
+    tracked = meeting.track_message(message=message(27, "unknown_lamer", "#vote +1", 555))
+    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.IN_FAVOR)
+    tracked = meeting.track_message(message=message(28, "layline", "#vote -1", 557))
+    meeting.track_event(event_type=EventType.VOTE, message=tracked, operand=VotingAction.OPPOSED)
+    tracked = meeting.track_message(message=message(29, "pronovic", "#close", 559))
+    meeting.track_event(event_type=EventType.ACCEPTED, message=tracked, operand="Motion accepted: 2 in favor to 1 opposed")
+
+    tracked = meeting.track_message(message=message(30, "pronovic", "#nick k[n", 560))
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="k[n")
+    tracked = meeting.track_message(message=message(31, "unknown_lamer", "#action hey k[n, your nick has special chars", 561))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="hey k[n, your nick has regex special characters")
+    tracked = meeting.track_message(message=message(32, "ken[", "#here", 562))
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="ke[")
+    meeting.track_attendee(nick="ken[", alias="ken[")
+    tracked = meeting.track_message(message=message(33, "layline", "#action ken] fix your nick!", 563))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="ken] fix your nick!")
+    tracked = meeting.track_message(message=message(34, "[ken", "#here", 564))
+    meeting.track_event(event_type=EventType.ATTENDEE, message=tracked, operand="[ken")
+    meeting.track_attendee(nick="[ken", alias="[ken")
+    tracked = meeting.track_message(message=message(35, "pronovic", "#action not you too, [ken", 565))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="not you too, [ken")
+    tracked = meeting.track_message(message=message(36, "[m]", "#here", 566))
+    meeting.track_attendee(nick="[m]", alias="[m]")
+    tracked = meeting.track_message(message=message(37, "keverets", "#action A Matrix [m] nick", 567))
+    meeting.track_event(event_type=EventType.ACTION, message=tracked, operand="A Matrix [m] nick")
+
+    # End the meeting
+    tracked = meeting.track_message(message=message(38, "pronovic", "#endmeeting", 570))
+    meeting.track_event(event_type=EventType.END_MEETING, message=tracked)
+    meeting.active = False
+    meeting.end_time = time(570)
+
+    return meeting


### PR DESCRIPTION
This is an incremental step in the implementation of issue #23 , which is a request to allow regenerating formatted output.  Currently, we don't persist the raw meeting state from the `Meeting` object.  So, there's no way to reprocess a meeting and generate new or updated HTML output.  This PR adds a 3rd generated file, which serializes `Meeting` to JSON.  At the same time, I did some refactoring so that the output format is configurable, although for the time being I only expect to support HTML.