### PR TITLE
conf_dir may be a path to a file

### DIFF
--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -65,7 +65,7 @@ class Config:
     output_format: OutputFormat = OUTPUT_FORMAT_DEFAULT
 
 
-def load_config(logger: Optional[Logger], conf_dir: str) -> Config:
+def load_config(logger: Optional[Logger], conf_path: str) -> Config:
     """
     Load configuration from disk.
 
@@ -75,10 +75,12 @@ def load_config(logger: Optional[Logger], conf_dir: str) -> Config:
 
     Args:
         logger(Logger): Python logger instance that should be used during processing
-        conf_dir(str): Limnoria bot conf directory to load configuration from
+        conf_path(str): Limnoria bot conf directory to load configuration from
     """
     config: Config
-    conf_file = os.path.join(conf_dir, CONF_FILE)
+    conf_file = conf_path
+    if os.path.isdir(conf_path):
+        conf_file = os.path.join(conf_path, CONF_FILE)
     if os.path.isfile(conf_file):
         try:
             parser = configparser.ConfigParser(interpolation=None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,18 @@ class TestParsing:
         assert config.use_channel_topic is True
         assert config.output_format == OutputFormat.HTML
 
+    def test_valid_custom_name_configuration(self):
+        logger = MagicMock()
+        conf_path = os.path.join(VALID_DIR, "CustomName.conf")
+        config = load_config(logger, conf_path)
+        assert config.conf_file == conf_path
+        assert config.log_dir == "/tmp/meetings"
+        assert config.url_prefix == "https://whatever/meetings"
+        assert config.pattern == "{name}-%Y%m%d"
+        assert config.timezone == "America/Chicago"
+        assert config.use_channel_topic is True
+        assert config.output_format == OutputFormat.HTML
+
     def test_valid_configuration_with_optional(self):
         logger = MagicMock()
         conf_dir = OPTIONAL_DIR


### PR DESCRIPTION
The regenerate command provides conf_dir as the path to the config file, however load_config is expecting the path to a directory. Change load_config to handle when the path is a file.