### PR TITLE
Fix load_config() to accept either a directory or a file

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,5 +1,6 @@
 Version 0.6.12     unreleased
 
+	* Fix load_config() to accept file or directory (by @achow101).
 	* Upgrade to gha-shared-workflows@v7 with publish improvements.
 
 Version 0.6.11     15 Oct 2024

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -330,7 +330,7 @@ Currently, the only utility available is ``regenerate``::
      will be generated using the exact same prefix as the raw log file itself.
 
    Options:
-     -c, --config <config>          Path to meetbot config file  [required]
+     -c, --config <config>          Path to config file or dir  [required]
      -r, --raw-log <raw-log>        Path to the raw JSON log  [required]
      -d, --output-dir <output-dir>  Where to write output, defaults to .
      -h, --help                     Show this message and exit.

--- a/src/hcoopmeetbotlogic/cli.py
+++ b/src/hcoopmeetbotlogic/cli.py
@@ -26,7 +26,7 @@ def meetbot() -> None:
     "-c",
     "config_path",
     metavar="<config>",
-    help="Path to meetbot config file",
+    help="Path to config file or dir",
     required=True,
 )
 @click.option(

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -69,9 +69,13 @@ def load_config(logger: Optional[Logger], conf_path: str) -> Config:
     """
     Load configuration from disk.
 
+    If conf_path is a directory, then HcoopMeetbot.conf will be loaded from
+    that directory.  If conf_path is a file, then that file will be loaded
+    instead.  If the entire file doesn't exist, defaults will be used for
+    all fields.
+
     The configuration on disk may contain any or all of the configuration fields.
     A default (fallback) value will be used for any field that does not exist.
-    If the entire file doesn't exist, defaults will be used for all fields.
 
     Args:
         logger(Logger): Python logger instance that should be used during processing

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -81,7 +81,7 @@ def load_config(logger: Optional[Logger], conf_path: str) -> Config:
     def parse_config(source: str) -> Config:
         if not os.path.isfile(source):
             if logger:
-                logger.debug("Could not find %s; using defaults", conf_path)
+                logger.debug("Could not find %s; using defaults", source)
             return Config(conf_file=None)
         try:
             parser = configparser.ConfigParser(interpolation=None)
@@ -99,7 +99,7 @@ def load_config(logger: Optional[Logger], conf_path: str) -> Config:
             )
         except Exception:  # pylint: disable=broad-except:
             if logger:
-                logger.exception("Failed to parse %s; using defaults", conf_path)
+                logger.exception("Failed to parse %s; using defaults", source)
             return Config(conf_file=None)
 
     conf_file = os.path.join(conf_path, CONF_FILE) if os.path.isdir(conf_path) else conf_path

--- a/src/hcoopmeetbotlogic/config.py
+++ b/src/hcoopmeetbotlogic/config.py
@@ -65,7 +65,7 @@ class Config:
     output_format: OutputFormat = OUTPUT_FORMAT_DEFAULT
 
 
-def load_config(logger: Optional[Logger], conf_dir: str) -> Config:
+def load_config(logger: Optional[Logger], conf_path: str) -> Config:
     """
     Load configuration from disk.
 
@@ -75,10 +75,12 @@ def load_config(logger: Optional[Logger], conf_dir: str) -> Config:
 
     Args:
         logger(Logger): Python logger instance that should be used during processing
-        conf_dir(str): Limnoria bot conf directory to load configuration from
+        conf_path(str): Limnoria bot conf directory to load configuration from
     """
     config: Config
-    conf_file = os.path.join(conf_dir, CONF_FILE)
+    conf_file = conf_path
+    if os.path.isdir(conf_path):
+        conf_file = os.path.join(conf_path, CONF_FILE)
     if os.path.isfile(conf_file):
         try:
             parser = configparser.ConfigParser(interpolation=None)

--- a/src/hcoopmeetbotlogic/handler.py
+++ b/src/hcoopmeetbotlogic/handler.py
@@ -22,16 +22,16 @@ def _send_reply(context: Context, reply: str) -> None:
 
 
 # noinspection PyShadowingNames
-def configure(logger: Logger, conf_dir: str) -> None:  # pylint: disable=redefined-outer-name:
+def configure(logger: Logger, conf_path: str) -> None:  # pylint: disable=redefined-outer-name:
     """
     Configure the plugin.
 
     Args:
         logger(Logger): Python logger instance that should be used during processing
-        conf_dir(str): Limnoria bot conf directory to load configuration from
+        conf_path(str): Limnoria bot config path to load configuration from, either a file or a directory
     """
     logger.debug("Configuring plugin")
-    config = load_config(logger, conf_dir)  # pylint: disable=redefined-outer-name:
+    config = load_config(logger, conf_path)  # pylint: disable=redefined-outer-name:
     set_logger(logger)
     set_config(config)
 

--- a/tests/fixtures/test_config/valid/CustomName.conf
+++ b/tests/fixtures/test_config/valid/CustomName.conf
@@ -1,0 +1,6 @@
+[HcoopMeetbot]
+logDir = /tmp/custom
+urlPrefix = https://whatever/custom
+pattern = {name}-%Y%m%d
+timezone = America/Chicago
+useChannelTopic = True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = VALID_DIR
         conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")  # if the caller provides a directory, we always load this file
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)
         assert config.conf_file == conf_file
         assert config.log_dir == "/tmp/meetings"
@@ -57,6 +58,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = VALID_DIR
         conf_file = os.path.join(conf_dir, "CustomName.conf")  # for anything other than a directory, we open it like a file
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_file)
         assert config.conf_file == conf_file
         assert config.log_dir == "/tmp/custom"
@@ -70,6 +72,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = OPTIONAL_DIR
         conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)
         assert config.conf_file == conf_file
         assert config.log_dir == "/tmp/meetings"
@@ -83,6 +86,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = NO_CHANNEL_DIR
         conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)
         assert config.conf_file == conf_file
         assert config.log_dir == "/tmp/meetings"
@@ -95,6 +99,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = EMPTY_DIR
         conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)  # any key that can't be loaded gets defaults
         assert config.conf_file == conf_file
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
@@ -106,10 +111,11 @@ class TestParsing:
     def test_bad_boolean_configuration(self):
         logger = MagicMock()
         conf_dir = BAD_BOOLEAN_DIR
-        conf_file = os.path.join(Path.home(), "hcoop-meetbot")
+        conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)  # since the boolean value is invalid, it's like the file doesn't exist
         assert config.conf_file is None
-        assert config.log_dir == conf_file
+        assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
         assert config.url_prefix == "/"
         assert config.pattern == "%Y/{name}.%Y%m%d.%H%M"
         assert config.timezone == "UTC"
@@ -118,6 +124,8 @@ class TestParsing:
     def test_bad_format_configuration(self):
         logger = MagicMock()
         conf_dir = BAD_FORMAT_DIR
+        conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)  # since the output format is invalid, it's like the file doesn't exist
         assert config.conf_file is None
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
@@ -129,7 +137,8 @@ class TestParsing:
     def test_invalid_configuration(self):
         logger = MagicMock()
         conf_dir = INVALID_DIR
-        conf_file = os.path.join(INVALID_DIR, "HcoopMeetbot.conf")
+        conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.isdir(conf_dir) and os.path.isfile(conf_file)
         config = load_config(logger, conf_dir)  # since the file is invalid, it's like the keys don't exist
         assert config.conf_file == conf_file
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
@@ -141,6 +150,7 @@ class TestParsing:
     def test_missing_configuration_dir(self):
         logger = MagicMock()
         conf_dir = MISSING_DIR
+        assert not os.path.exists(conf_dir)
         config = load_config(logger, conf_dir)  # if the directory does not exist, we use defaults
         assert config.conf_file is None
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
@@ -151,6 +161,8 @@ class TestParsing:
     def test_missing_configuration_file_default(self):
         logger = MagicMock()
         conf_dir = NO_FILE_DIR
+        conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        assert os.path.exists(conf_dir) and not os.path.exists(conf_file)
         config = load_config(logger, conf_dir)  # if the directory exists, but the file does not exist within, we use defaults
         assert config.conf_file is None
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")
@@ -162,6 +174,7 @@ class TestParsing:
         logger = MagicMock()
         conf_dir = NO_FILE_DIR
         conf_file = os.path.join(conf_dir, "AnyFile.conf")
+        assert os.path.exists(conf_dir) and not os.path.exists(conf_file)
         config = load_config(logger, conf_file)  # if the directory exists, but the file does not exist within, we use defaults
         assert config.conf_file is None
         assert config.log_dir == os.path.join(Path.home(), "hcoop-meetbot")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,8 +42,10 @@ class TestParsing:
     def test_valid_configuration(self):
         logger = MagicMock()
         conf_dir = VALID_DIR
-        config = load_config(logger, conf_dir)
-        assert config.conf_file == os.path.join(VALID_DIR, "HcoopMeetbot.conf")
+        conf_file = os.path.join(conf_dir, "HcoopMeetbot.conf")
+        conf_path = conf_dir
+        config = load_config(logger, conf_path)
+        assert config.conf_file == conf_file
         assert config.log_dir == "/tmp/meetings"
         assert config.url_prefix == "https://whatever/meetings"
         assert config.pattern == "{name}-%Y%m%d"
@@ -53,11 +55,13 @@ class TestParsing:
 
     def test_valid_custom_name_configuration(self):
         logger = MagicMock()
-        conf_path = os.path.join(VALID_DIR, "CustomName.conf")
+        conf_dir = VALID_DIR
+        conf_file = os.path.join(conf_dir, "CustomName.conf")
+        conf_path = conf_file
         config = load_config(logger, conf_path)
-        assert config.conf_file == conf_path
-        assert config.log_dir == "/tmp/meetings"
-        assert config.url_prefix == "https://whatever/meetings"
+        assert config.conf_file == conf_file
+        assert config.log_dir == "/tmp/custom"
+        assert config.url_prefix == "https://whatever/custom"
         assert config.pattern == "{name}-%Y%m%d"
         assert config.timezone == "America/Chicago"
         assert config.use_channel_topic is True

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -51,6 +51,18 @@ class TestParsing:
         assert config.use_channel_topic is True
         assert config.output_format == OutputFormat.HTML
 
+    def test_valid_custom_name_configuration(self):
+        logger = MagicMock()
+        conf_path = os.path.join(VALID_DIR, "CustomName.conf")
+        config = load_config(logger, conf_path)
+        assert config.conf_file == conf_path
+        assert config.log_dir == "/tmp/meetings"
+        assert config.url_prefix == "https://whatever/meetings"
+        assert config.pattern == "{name}-%Y%m%d"
+        assert config.timezone == "America/Chicago"
+        assert config.use_channel_topic is True
+        assert config.output_format == OutputFormat.HTML
+
     def test_valid_configuration_with_optional(self):
         logger = MagicMock()
         conf_dir = OPTIONAL_DIR


### PR DESCRIPTION
This is based on PR #45, provided by @achow101 .  The `regenerate` command calls `load_config()` and passes the full path to a config file on disk.  However, `load_config()` actually accepts a directory instead.   This fixes `load_config()` so it accepts either a directory or a file.  This way, the `regenerate` command works as intended, while maintaining compatibility with other code that calls `load_config()`.  I took the original implementation from PR #45 and adjusted it to cover some additional corner cases when checking for existence of the file or directory.  I also expanded the unit tests to get better coverage.
