### PR TITLE
Ignore commands containing numbers and the channel name

### DIFF
--- a/src/hcoopmeetbotlogic/command.py
+++ b/src/hcoopmeetbotlogic/command.py
@@ -280,6 +280,8 @@ def dispatch(meeting: Meeting, context: Context, message: TrackedMessage) -> Non
         operand = operation_match.group(_OPERAND_GROUP).strip()
         if hasattr(_DISPATCHER, "%s%s" % (_METHOD_PREFIX, operation)):
             getattr(_DISPATCHER, "%s%s" % (_METHOD_PREFIX, operation))(meeting, context, operation, operand, message)
+        elif message.payload.lower().strip().startswith(meeting.channel.lower()):
+            return
         else:
             context.send_reply("Unknown command: #%s" % operation)
     elif url_match:

--- a/src/hcoopmeetbotlogic/command.py
+++ b/src/hcoopmeetbotlogic/command.py
@@ -22,7 +22,7 @@ from .writer import write_meeting
 _STARTMEETING_REGEX = re.compile(r"(^\s*)(#)(startmeeting)(\s*)(.*$)", re.IGNORECASE)
 
 # Regular expression to identify a command in a message
-_OPERATION_REGEX = re.compile(r"(^\s*)(#)(\w+)(\s*)(.*$)", re.IGNORECASE)
+_OPERATION_REGEX = re.compile(r"(^\s*)(#)([a-zA-Z_]+)($|\s+)(.*$)", re.IGNORECASE)
 _OPERATION_GROUP = 3
 _OPERAND_GROUP = 5
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -127,7 +127,7 @@ class TestFunctions:
     @patch("hcoopmeetbotlogic.command.hasattr")
     @patch("hcoopmeetbotlogic.command.getattr")
     def test_dispatch_invalid_command(self, _getattr, _hasattr):  # pylint: disable=redefined-builtin:
-        meeting = MagicMock()
+        meeting = MagicMock(channel="chan")
         context = MagicMock()
         message = MagicMock(payload="#bogus")
         _hasattr.return_value = False
@@ -138,8 +138,10 @@ class TestFunctions:
     @patch("hcoopmeetbotlogic.command.hasattr")
     @patch("hcoopmeetbotlogic.command.getattr")
     def test_dispatch_non_commands(self, _getattr, _hasattr):  # pylint: disable=redefined-builtin:
-        def run_ignored_dispatch(payload):
-            meeting = MagicMock()
+        def run_ignored_dispatch(payload, channel=None):
+            if channel is None:
+                channel = "#channel"
+            meeting = MagicMock(channel=channel)
             context = MagicMock()
             message = MagicMock(payload=payload)
             _hasattr.return_value = False
@@ -152,6 +154,8 @@ class TestFunctions:
         run_ignored_dispatch("#asdf1234")
         run_ignored_dispatch("#a2s3d4f")
         run_ignored_dispatch("#2s3d4f")
+        run_ignored_dispatch("#channame", "#channame")
+        run_ignored_dispatch("  #channame", "#channame")
 
     # noinspection PyTypeChecker
     @patch("hcoopmeetbotlogic.command._DISPATCHER")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -135,6 +135,24 @@ class TestFunctions:
         _getattr.assert_not_called()
         context.send_reply.assert_called_once_with("Unknown command: #bogus")
 
+    @patch("hcoopmeetbotlogic.command.hasattr")
+    @patch("hcoopmeetbotlogic.command.getattr")
+    def test_dispatch_non_commands(self, _getattr, _hasattr):  # pylint: disable=redefined-builtin:
+        def run_ignored_dispatch(payload):
+            meeting = MagicMock()
+            context = MagicMock()
+            message = MagicMock(payload=payload)
+            _hasattr.return_value = False
+            dispatch(meeting, context, message)
+            _getattr.assert_not_called()
+            context.send_reply.assert_not_called()
+
+        run_ignored_dispatch("#1234")
+        run_ignored_dispatch("  #1234")
+        run_ignored_dispatch("#asdf1234")
+        run_ignored_dispatch("#a2s3d4f")
+        run_ignored_dispatch("#2s3d4f")
+
     # noinspection PyTypeChecker
     @patch("hcoopmeetbotlogic.command._DISPATCHER")
     def test_dispatch_command_variations(self, dispatcher):


### PR DESCRIPTION
For the channel that I've setup meetbot in, we frequently use `#<pr number>` to refer to PRs, and a separate bot detects these and links them. However, when a message begins with that format, meetbot will also send an unknown command message, which is noisy. Since there are no commands that include numbers, this PR updates the regex to exclude numbers from the match.

Additionally, in that channel, we often begin meetings with a message that starts with `#<channel name>`. Meetbot also detects this as an unknown command and informs us as such. This is also noisy, so the PR also adds a check for such messages in order to ignore them.

https://achow101.com/ircmeetings/2025/bitcoin-core-dev.2025-01-23_16_00.log.html is an example of a meeting where the undesired messages appear.