### PR TITLE
Update the MyPy configuration so we're using latest rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,11 +156,6 @@ module = "tests.*"
 check_untyped_defs = false
 allow_untyped_defs = true
 
-# There is no type hinting for pytest
-[[tool.mypy.overrides]]
-module = "pytest"
-ignore_missing_imports = true
-
 # There is no type hinting for genshi
 [[tool.mypy.overrides]]
 module = "genshi.*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,12 +124,12 @@ filterwarnings = [
 ]
 
 [tool.mypy]
-# Settings are mostly equivalent to strict=true as of v1.14.1
+files = [ "src" ]
 pretty = true
 show_absolute_path = true
 show_column_numbers = true
 show_error_codes = true
-files = [ "src/HcoopMeetbot", "src/tests/hcoopmeetbotlogic" ]  # TODO: this should scan all source
+# Settings equivalent to strict=true as of v1.17.1
 check_untyped_defs = true
 disallow_any_generics = true
 disallow_incomplete_defs = true
@@ -137,15 +137,18 @@ disallow_subclassing_any = true
 disallow_untyped_calls = true
 disallow_untyped_decorators = false
 disallow_untyped_defs = true
-no_implicit_optional = true
+extra_checks = true
 no_implicit_reexport = true
 strict_equality = true
-strict_optional = true
 warn_redundant_casts = true
 warn_return_any = true
-warn_no_return = true
 warn_unused_configs = true
 warn_unused_ignores = true
+# Additional settings above and beyond strict=true
+implicit_optional = false
+strict_optional = true
+warn_no_return = true
+warn_unreachable = true
 
 # It's hard to make tests compliant using unittest.mock
 [[tool.mypy.overrides]]

--- a/src/hcoopmeetbotlogic/meeting.py
+++ b/src/hcoopmeetbotlogic/meeting.py
@@ -27,7 +27,7 @@ class _CattrConverter(cattrs.GenConverter):
 
     def __init__(self) -> None:
         super().__init__()
-        self.register_unstructure_hook(datetime, lambda d: d.isoformat() if d else None)  # type: ignore
+        self.register_unstructure_hook(datetime, lambda d: d.isoformat() if d else None)
         self.register_structure_hook(datetime, lambda s, _: datetime.fromisoformat(s) if s else None)
 
 

--- a/src/hcoopmeetbotlogic/state.py
+++ b/src/hcoopmeetbotlogic/state.py
@@ -37,13 +37,13 @@ except NameError:
 
 try:
     # noinspection PyUnresolvedReferences,PyUnboundLocalVariable
-    _ACTIVE  # pylint: disable=used-before-assignment:
+    _ACTIVE  # type: ignore[used-before-def]
 except NameError:
     _ACTIVE: Dict[str, Meeting] = {}
 
 try:
     # noinspection PyUnresolvedReferences,PyUnboundLocalVariable
-    _COMPLETED  # pylint: disable=used-before-assignment:
+    _COMPLETED  # type: ignore[used-before-def]
 except NameError:
     _COMPLETED: Deque[Meeting] = deque([], _COMPLETED_SIZE)
 

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -151,26 +151,26 @@ class _AliasMatcher:
 
     nick: str
     alias: Optional[str]
-    nick_pattern: re.Pattern = field()
-    alias_pattern: Optional[re.Pattern] = field()
+    nick_pattern: re.Pattern[str] = field()
+    alias_pattern: Optional[re.Pattern[str]] = field()
 
     @nick_pattern.default
-    def _nick_pattern_default(self) -> re.Pattern:
+    def _nick_pattern_default(self) -> re.Pattern[str]:
         return _AliasMatcher._regex(self.nick)
 
     @alias_pattern.default
-    def _alias_pattern_default(self) -> Optional[re.Pattern]:
+    def _alias_pattern_default(self) -> Optional[re.Pattern[str]]:
         return _AliasMatcher._regex(self.alias) if self.alias else None
 
     @staticmethod
-    def _regex(identifier) -> re.Pattern:
+    def _regex(identifier: str) -> re.Pattern[str]:
         escaped = re.escape(identifier)
         regex = r"(^|\s)(%s|%s:|\(%s\))($|\s)" % (escaped, escaped, escaped)
         return re.compile(regex, re.IGNORECASE)
 
     def matches(self, message: str) -> bool:
         """Return true if the attendee nick or alias is found in the message."""
-        return bool(self.nick_pattern.search(message)) or (self.alias_pattern and self.alias_pattern.search(message))
+        return bool(self.nick_pattern.search(message)) or bool(self.alias_pattern and self.alias_pattern.search(message))
 
 
 @frozen


### PR DESCRIPTION
This updates the MyPy configuration, adding a few new flags and making adjustments so it's clear which flags are related to `--strict` and which are other flags that I've added above and beyond that. Prototyped in [apologies PR #67](https://github.com/pronovic/apologies/pull/67).

**Note:** at the same time, I also fixed an oversight where we were accidentally checking only part of the codebase.  This was definitely not intentional, but I'm not sure when I broke it.