### PR TITLE
Replace black/isort with ruff formatter

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   linux-build-and-test:
     name: "Linux"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v8
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v9
     secrets: inherit
     with:
       matrix-os-version: "[ 'ubuntu-latest' ]"
@@ -23,7 +23,7 @@ jobs:
       persist-python-version: "3.10"  # persist artifacts for the oldest supported Python version
   macos-build-and-test:
     name: "MacOS"
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v8
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-build-and-test.yml@v9
     secrets: inherit
     with:
       matrix-os-version: "[ 'macos-latest' ]"
@@ -31,7 +31,7 @@ jobs:
   release:
     name: "Release"
     if: github.ref_type == 'tag'
-    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v8
+    uses: pronovic/gha-shared-workflows/.github/workflows/poetry-release.yml@v9
     needs: [ linux-build-and-test, macos-build-and-test ]
     secrets: inherit
     with:

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ __pycache__
 /.mypy_cache
 /.idea/MypyConfig.xml 
 
+# Ruff
+.ruff_cache
+
 # Generated docs and code distribution
 /src/*.egg-info
 /docs/_build

--- a/.run/commands/black.sh
+++ b/.run/commands/black.sh
@@ -1,9 +1,0 @@
-# vim: set ft=bash ts=3 sw=3 expandtab:
-# Run the black code formatter
-
-command_black() {
-   echo "Running black formatter..."
-   poetry_run black "$@" .
-   echo "done"
-}
-

--- a/.run/commands/clean.sh
+++ b/.run/commands/clean.sh
@@ -9,6 +9,7 @@ command_clean() {
    rm -rf .coverage*
    rm -rf .tox
    rm -rf .mypy_cache
+   rm -rf .ruff_cache
    rm -rf docs/_build
    rm -rf dist
    rm -rf .poetry

--- a/.run/commands/isort.sh
+++ b/.run/commands/isort.sh
@@ -1,9 +1,0 @@
-# vim: set ft=bash ts=3 sw=3 expandtab:
-# Run the isort import formatter
-
-command_isort() {
-   echo "Running isort formatter..."
-   poetry_run isort --color "$@" .
-   echo "done"
-}
-

--- a/.run/commands/ruffformat.sh
+++ b/.run/commands/ruffformat.sh
@@ -1,0 +1,9 @@
+# vim: set ft=bash ts=3 sw=3 expandtab:
+# Run the Ruff code formatter
+
+command_ruffformat() {
+   echo "Running Ruff formatter..."
+   poetry_run ruff format "$@"
+   echo "done"
+}
+

--- a/.run/tasks/checks.sh
+++ b/.run/tasks/checks.sh
@@ -8,9 +8,7 @@ task_checks() {
    echo ""
    run_command checktabs
    echo ""
-   run_command black --check
-   echo ""
-   run_command isort --check-only
+   run_command ruffformat --check
    echo ""
    run_command mypy
    echo ""

--- a/.run/tasks/format.sh
+++ b/.run/tasks/format.sh
@@ -5,9 +5,6 @@ help_format() {
 }
 
 task_format() {
-   echo ""
-   run_command black
-   echo ""
-   run_command isort
+   run_command ruffformat
 }
 

--- a/Changelog
+++ b/Changelog
@@ -3,6 +3,7 @@ Version 0.6.16     unreleased
 	* Adjust GHA build process to allow builds for stacked PRs.
 	* Add a new `run clean` target to clean up generated data.
 	* Move unit tests from `tests` into `src/tests/hcoopmeetbotlogic`.
+	* Replace black and isort tools with the Ruff formatter.
 	* Update the jinja2 transitive dependency to address CVE-2025-27516.
 	* Update the requests transitive dependency to address CVE-2024-47081.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -27,7 +27,7 @@ suites and combines the coverage results together into a single report.
 
 This project uses [Poetry v2](https://python-poetry.org/) to manage Python packaging and dependencies.  Most day-to-day tasks (such as running unit tests from the command line) are orchestrated through Poetry.
 
-A coding standard is enforced using [Black](https://pypi.org/project/black/), [isort](https://pypi.org/project/isort/) and [Pylint](https://pypi.org/project/pylint/).  Python 3 type hinting is validated using [MyPy](https://pypi.org/project/mypy/).  To reduce boilerplate, classes are defined using [Attrs](https://www.attrs.org/) (see this [rationale](https://glyph.twistedmatrix.com/2016/08/attrs.html)).
+A coding standard is enforced using [Ruff](https://docs.astral.sh/ruff/) and [Pylint](https://pypi.org/project/pylint/).  Python 3 type hinting is validated using [MyPy](https://pypi.org/project/mypy/).  To reduce boilerplate, classes are defined using [Attrs](https://www.attrs.org/) (see this [rationale](https://glyph.twistedmatrix.com/2016/08/attrs.html)).
 
 ## Pre-Commit Hooks
 
@@ -202,8 +202,8 @@ doesn't seem to work as expected, just use CTRL-C.
 ## Integration with PyCharm
 
 Currently, I use [PyCharm Community Edition](https://www.jetbrains.com/pycharm/download) as
-my day-to-day IDE.  By integrating Black and Pylint, most everything important
-that can be done from a shell environment can also be done right in PyCharm.
+my day-to-day IDE.  By integrating Ruff, most everything important that can be
+done from a shell environment can also be done right in PyCharm.
 
 PyCharm offers a good developer experience.  However, the underlying configuration
 on disk mixes together project policy (i.e. preferences about which test runner to
@@ -304,7 +304,7 @@ source ~/.bash_profile
 |Field|Value|
 |-----|-----|
 |Name|`Format Code`|
-|Description|`Run the Black and isort code formatters`|
+|Description|`Run the Ruff code formatter`|
 |Group|`Developer Tools`|
 |Program|`$ProjectFileDir$/run`|
 |Arguments|`format`|

--- a/poetry.lock
+++ b/poetry.lock
@@ -66,53 +66,6 @@ files = [
 dev = ["freezegun (>=1.0,<2.0)", "pytest (>=6.0)", "pytest-cov"]
 
 [[package]]
-name = "black"
-version = "24.10.0"
-description = "The uncompromising code formatter."
-optional = false
-python-versions = ">=3.9"
-groups = ["dev"]
-files = [
-    {file = "black-24.10.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6668650ea4b685440857138e5fe40cde4d652633b1bdffc62933d0db4ed9812"},
-    {file = "black-24.10.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c536fcf674217e87b8cc3657b81809d3c085d7bf3ef262ead700da345bfa6ea"},
-    {file = "black-24.10.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:649fff99a20bd06c6f727d2a27f401331dc0cc861fb69cde910fe95b01b5928f"},
-    {file = "black-24.10.0-cp310-cp310-win_amd64.whl", hash = "sha256:fe4d6476887de70546212c99ac9bd803d90b42fc4767f058a0baa895013fbb3e"},
-    {file = "black-24.10.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5a2221696a8224e335c28816a9d331a6c2ae15a2ee34ec857dcf3e45dbfa99ad"},
-    {file = "black-24.10.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:f9da3333530dbcecc1be13e69c250ed8dfa67f43c4005fb537bb426e19200d50"},
-    {file = "black-24.10.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4007b1393d902b48b36958a216c20c4482f601569d19ed1df294a496eb366392"},
-    {file = "black-24.10.0-cp311-cp311-win_amd64.whl", hash = "sha256:394d4ddc64782e51153eadcaaca95144ac4c35e27ef9b0a42e121ae7e57a9175"},
-    {file = "black-24.10.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b5e39e0fae001df40f95bd8cc36b9165c5e2ea88900167bddf258bacef9bbdc3"},
-    {file = "black-24.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:d37d422772111794b26757c5b55a3eade028aa3fde43121ab7b673d050949d65"},
-    {file = "black-24.10.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14b3502784f09ce2443830e3133dacf2c0110d45191ed470ecb04d0f5f6fcb0f"},
-    {file = "black-24.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:30d2c30dc5139211dda799758559d1b049f7f14c580c409d6ad925b74a4208a8"},
-    {file = "black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981"},
-    {file = "black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b"},
-    {file = "black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2"},
-    {file = "black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b"},
-    {file = "black-24.10.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17374989640fbca88b6a448129cd1745c5eb8d9547b464f281b251dd00155ccd"},
-    {file = "black-24.10.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:63f626344343083322233f175aaf372d326de8436f5928c042639a4afbbf1d3f"},
-    {file = "black-24.10.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfa1d0cb6200857f1923b602f978386a3a2758a65b52e0950299ea014be6800"},
-    {file = "black-24.10.0-cp39-cp39-win_amd64.whl", hash = "sha256:2cd9c95431d94adc56600710f8813ee27eea544dd118d45896bb734e9d7a0dc7"},
-    {file = "black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d"},
-    {file = "black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875"},
-]
-
-[package.dependencies]
-click = ">=8.0.0"
-mypy-extensions = ">=0.4.3"
-packaging = ">=22.0"
-pathspec = ">=0.9.0"
-platformdirs = ">=2"
-tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = {version = ">=4.0.1", markers = "python_version < \"3.11\""}
-
-[package.extras]
-colorama = ["colorama (>=0.4.3)"]
-d = ["aiohttp (>=3.10)"]
-jupyter = ["ipython (>=7.8.0)", "tokenize-rt (>=3.2.0)"]
-uvloop = ["uvloop (>=0.15.2)"]
-
-[[package]]
 name = "cattrs"
 version = "24.1.2"
 description = "Composable complex class support for attrs and dataclasses."
@@ -273,7 +226,7 @@ version = "8.1.8"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.7"
-groups = ["main", "dev"]
+groups = ["main"]
 files = [
     {file = "click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2"},
     {file = "click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a"},
@@ -770,18 +723,6 @@ files = [
 markers = {main = "extra == \"docs\""}
 
 [[package]]
-name = "pathspec"
-version = "0.12.1"
-description = "Utility library for gitignore style pattern matching of file paths."
-optional = false
-python-versions = ">=3.8"
-groups = ["dev"]
-files = [
-    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
-    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
-]
-
-[[package]]
 name = "platformdirs"
 version = "4.3.6"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
@@ -1015,6 +956,35 @@ urllib3 = ">=1.21.1,<3"
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+
+[[package]]
+name = "ruff"
+version = "0.12.10"
+description = "An extremely fast Python linter and code formatter, written in Rust."
+optional = false
+python-versions = ">=3.7"
+groups = ["dev"]
+files = [
+    {file = "ruff-0.12.10-py3-none-linux_armv6l.whl", hash = "sha256:8b593cb0fb55cc8692dac7b06deb29afda78c721c7ccfed22db941201b7b8f7b"},
+    {file = "ruff-0.12.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ebb7333a45d56efc7c110a46a69a1b32365d5c5161e7244aaf3aa20ce62399c1"},
+    {file = "ruff-0.12.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d59e58586829f8e4a9920788f6efba97a13d1fa320b047814e8afede381c6839"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:822d9677b560f1fdeab69b89d1f444bf5459da4aa04e06e766cf0121771ab844"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:37b4a64f4062a50c75019c61c7017ff598cb444984b638511f48539d3a1c98db"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2c6f4064c69d2542029b2a61d39920c85240c39837599d7f2e32e80d36401d6e"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:059e863ea3a9ade41407ad71c1de2badfbe01539117f38f763ba42a1206f7559"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bef6161e297c68908b7218fa6e0e93e99a286e5ed9653d4be71e687dff101cf"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4f1345fbf8fb0531cd722285b5f15af49b2932742fc96b633e883da8d841896b"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f68433c4fbc63efbfa3ba5db31727db229fa4e61000f452c540474b03de52a9"},
+    {file = "ruff-0.12.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:141ce3d88803c625257b8a6debf4a0473eb6eed9643a6189b68838b43e78165a"},
+    {file = "ruff-0.12.10-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f3fc21178cd44c98142ae7590f42ddcb587b8e09a3b849cbc84edb62ee95de60"},
+    {file = "ruff-0.12.10-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7d1a4e0bdfafcd2e3e235ecf50bf0176f74dd37902f241588ae1f6c827a36c56"},
+    {file = "ruff-0.12.10-py3-none-musllinux_1_2_i686.whl", hash = "sha256:e67d96827854f50b9e3e8327b031647e7bcc090dbe7bb11101a81a3a2cbf1cc9"},
+    {file = "ruff-0.12.10-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:ae479e1a18b439c59138f066ae79cc0f3ee250712a873d00dbafadaad9481e5b"},
+    {file = "ruff-0.12.10-py3-none-win32.whl", hash = "sha256:9de785e95dc2f09846c5e6e1d3a3d32ecd0b283a979898ad427a9be7be22b266"},
+    {file = "ruff-0.12.10-py3-none-win_amd64.whl", hash = "sha256:7837eca8787f076f67aba2ca559cefd9c5cbc3a9852fd66186f4201b87c1563e"},
+    {file = "ruff-0.12.10-py3-none-win_arm64.whl", hash = "sha256:cc138cc06ed9d4bfa9d667a65af7172b47840e1a98b02ce7011c391e54635ffc"},
+    {file = "ruff-0.12.10.tar.gz", hash = "sha256:189ab65149d11ea69a2d775343adf5f49bb2426fc4780f65ee33b423ad2e47f9"},
+]
 
 [[package]]
 name = "six"
@@ -1353,4 +1323,4 @@ docs = ["importlib-metadata", "sphinx", "sphinx-autoapi"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "848973ba7efd8cb3502f9f3715dccca35430c8c28d65464a5e0b65a8e92c59d3"
+content-hash = "945ccfbaccdbb641364a293a300ad9de2d599e76dc0d79cf904dc10537f3da3c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,37 +72,13 @@ pytest-testdox = ">=3.1.0,<4.0.0"
 coverage = ">=7.4.4,<8.0.0"
 pylint = ">=3.0.1,<4.0.0"
 pre-commit = ">=4.0.1,<5.0.0"
-black = ">=24.2.0,<25.0.0"
 mypy = ">=1.6.0,<2.0.0"
-isort = ">=5.12.0,<6.0.0"
 colorama = ">=0.4.6,<1.0.0"
 types-pytz = ">=2023.3.1.1"
+ruff = "^0.12.10"
 
 [tool.poetry.scripts]
 meetbot = "hcoopmeetbotlogic.cli:meetbot"
-
-[tool.black]
-line-length = 132
-target-version = [ 'py310', 'py311', 'py312', 'py313' ]
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git
-  | __pycache__
-  | \.tox
-  | \.venv
-  | \.poetry
-  | build
-  | dist
-  | docs
-  | notes
-)/
-'''
-
-[tool.isort]
-profile = "black"
-line_length = 132
-skip_glob = [ "docs", "notes", ".poetry" ]
 
 [tool.coverage.paths]
 source = [ "src" ]
@@ -122,6 +98,18 @@ filterwarnings = [
     'ignore:.*Flags not at the start of the expression::genshi', # warning in Genshi code we do not control
     'ignore:.*_init__ missing 1 required positional argument::genshi', # warning in Genshi code we do not control
 ]
+
+[tool.ruff]
+src = ["src"]
+extend-exclude = [ "docs", "notes", ".poetry" ]
+line-length = 132
+preview = true
+
+[tool.ruff.format]
+quote-style = "double"
+line-ending = "lf"
+docstring-code-format = true
+docstring-code-line-length = 80
 
 [tool.mypy]
 files = [ "src" ]

--- a/src/HcoopMeetbot/__init__.py
+++ b/src/HcoopMeetbot/__init__.py
@@ -7,6 +7,7 @@
 """
 HcoopMeetbot: Plugin for Limnoria to help run IRC meetings
 """
+
 from importlib import reload
 from typing import Dict
 

--- a/src/hcoopmeetbotlogic/cli.py
+++ b/src/hcoopmeetbotlogic/cli.py
@@ -4,6 +4,7 @@
 """
 CLI for the meetbot tool.
 """
+
 import os
 
 import click

--- a/src/hcoopmeetbotlogic/dateutil.py
+++ b/src/hcoopmeetbotlogic/dateutil.py
@@ -4,6 +4,7 @@
 """
 Date utilities.
 """
+
 from datetime import datetime
 from typing import Optional
 

--- a/src/hcoopmeetbotlogic/interface.py
+++ b/src/hcoopmeetbotlogic/interface.py
@@ -4,6 +4,7 @@
 """
 Object interface used by plugin to access code in the local package.
 """
+
 from datetime import datetime
 from typing import Callable, Iterable, Optional
 

--- a/src/hcoopmeetbotlogic/location.py
+++ b/src/hcoopmeetbotlogic/location.py
@@ -4,6 +4,7 @@
 """
 Location logic.
 """
+
 import os
 import re
 from pathlib import Path

--- a/src/hcoopmeetbotlogic/writer.py
+++ b/src/hcoopmeetbotlogic/writer.py
@@ -117,13 +117,11 @@ class _LogMessage:
 
     @staticmethod
     def _payload(payload: str) -> Element:
-        return tag.span(
-            [
-                tag.span(element, class_="hi") if _NICK_REGEX.fullmatch(element) else tag.span(element)
-                for element in _NICK_REGEX.split(payload, 1)
-                if element
-            ]
-        )
+        return tag.span([
+            tag.span(element, class_="hi") if _NICK_REGEX.fullmatch(element) else tag.span(element)
+            for element in _NICK_REGEX.split(payload, 1)
+            if element
+        ])
 
 
 @frozen

--- a/src/tests/hcoopmeetbotlogic/test_command.py
+++ b/src/tests/hcoopmeetbotlogic/test_command.py
@@ -197,15 +197,13 @@ class TestCommandDispatcher:
         dispatcher.do_startmeeting(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.START_MEETING, message)
         context.set_topic.assert_called_once_with("The Topic")
-        context.send_reply.assert_has_calls(
-            [
-                call("Meeting started at 11111"),
-                call("Current chairs: x, y"),
-                call("Useful commands: #action #info #idea #link #topic #motion #vote #close #endmeeting"),
-                call("See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
-                call("Participants should now identify themselves with '#here' or with an alias like '#here FirstLast'"),
-            ]
-        )
+        context.send_reply.assert_has_calls([
+            call("Meeting started at 11111"),
+            call("Current chairs: x, y"),
+            call("Useful commands: #action #info #idea #link #topic #motion #vote #close #endmeeting"),
+            call("See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
+            call("Participants should now identify themselves with '#here' or with an alias like '#here FirstLast'"),
+        ])
         assert meeting.original_topic == "original"
         formatdate.assert_called_once_with(timestamp=meeting.start_time, zone="America/Chicago")
 
@@ -224,15 +222,13 @@ class TestCommandDispatcher:
         dispatcher.do_startmeeting(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.START_MEETING, message)
         context.set_topic.assert_not_called()
-        context.send_reply.assert_has_calls(
-            [
-                call("Meeting started at 11111"),
-                call("Current chairs: x, y"),
-                call("Useful commands: #action #info #idea #link #topic #motion #vote #close #endmeeting"),
-                call("See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
-                call("Participants should now identify themselves with '#here' or with an alias like '#here FirstLast'"),
-            ]
-        )
+        context.send_reply.assert_has_calls([
+            call("Meeting started at 11111"),
+            call("Current chairs: x, y"),
+            call("Useful commands: #action #info #idea #link #topic #motion #vote #close #endmeeting"),
+            call("See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
+            call("Participants should now identify themselves with '#here' or with an alias like '#here FirstLast'"),
+        ])
         assert meeting.original_topic == "original"
         formatdate.assert_called_once_with(timestamp=meeting.start_time, zone="America/Chicago")
 
@@ -280,9 +276,12 @@ class TestCommandDispatcher:
         dispatcher.do_endmeeting(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.END_MEETING, message)
         write_meeting.assert_called_once_with(config=config.return_value, meeting=meeting)
-        context.send_reply.assert_has_calls(
-            [call("Meeting ended at 11111"), call("Raw log: rawurl"), call("Formatted log: logurl"), call("Minutes: minutesurl")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Meeting ended at 11111"),
+            call("Raw log: rawurl"),
+            call("Formatted log: logurl"),
+            call("Minutes: minutesurl"),
+        ])
         context.set_topic.assert_called_once_with("original")
         formatdate.assert_called_once_with(timestamp=now.return_value, zone="America/Chicago")
         deactivate_meeting.assert_called_once_with(meeting, retain=True)
@@ -314,9 +313,12 @@ class TestCommandDispatcher:
         dispatcher.do_save(meeting, context, "a", "b", message)
         meeting.track_event.assert_called_once_with(EventType.SAVE_MEETING, message)
         write_meeting.assert_called_once_with(config=config.return_value, meeting=meeting)
-        context.send_reply.assert_has_calls(
-            [call("Meeting saved"), call("Raw log: rawurl"), call("Formatted log: logurl"), call("Minutes: minutesurl")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Meeting saved"),
+            call("Raw log: rawurl"),
+            call("Formatted log: logurl"),
+            call("Minutes: minutesurl"),
+        ])
 
     @patch("hcoopmeetbotlogic.command.write_meeting")
     def test_save_as_not_chair(self, write_meeting, dispatcher, meeting, context, message):
@@ -388,16 +390,14 @@ class TestCommandDispatcher:
         meeting.track_event.assert_called_once_with(
             EventType.ADD_CHAIR, message, operand=["one", "two", "three", "four", "five", "six"]
         )
-        meeting.add_chair.assert_has_calls(
-            [
-                call("one", primary=False),
-                call("two", primary=False),
-                call("three", primary=False),
-                call("four", primary=False),
-                call("five", primary=False),
-                call("six", primary=False),
-            ]
-        )
+        meeting.add_chair.assert_has_calls([
+            call("one", primary=False),
+            call("two", primary=False),
+            call("three", primary=False),
+            call("four", primary=False),
+            call("five", primary=False),
+            call("six", primary=False),
+        ])
         context.send_reply.assert_called_once_with("Current chairs: x, y")
 
     def test_chair_as_not_chair(self, dispatcher, meeting, context, message):
@@ -472,16 +472,14 @@ class TestCommandDispatcher:
         meeting.track_event.assert_called_once_with(
             EventType.TRACK_NICK, message, operand=["one", "two", "three", "four", "five", "six"]
         )
-        meeting.track_nick.assert_has_calls(
-            [
-                call("one", messages=0),
-                call("two", messages=0),
-                call("three", messages=0),
-                call("four", messages=0),
-                call("five", messages=0),
-                call("six", messages=0),
-            ]
-        )
+        meeting.track_nick.assert_has_calls([
+            call("one", messages=0),
+            call("two", messages=0),
+            call("three", messages=0),
+            call("four", messages=0),
+            call("five", messages=0),
+            call("six", messages=0),
+        ])
         context.send_reply.assert_called_once_with("Current nicks: x, y")
 
     def test_undo_as_chair_no_events(self, dispatcher, meeting, context, message):
@@ -608,9 +606,11 @@ class TestCommandDispatcher:
         assert meeting.motion_index is None
         meeting.is_chair.assert_called_once_with("nick")  # message.sender
         meeting.track_event.assert_called_once_with(EventType.ACCEPTED, message, operand="Motion accepted: 2 in favor to 1 opposed")
-        context.send_reply.assert_has_calls(
-            [call("Motion accepted: 2 in favor to 1 opposed"), call("In favor: one, two"), call("Opposed: three")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Motion accepted: 2 in favor to 1 opposed"),
+            call("In favor: one, two"),
+            call("Opposed: three"),
+        ])
 
     def test_close_accepted_unanimous(self, dispatcher, meeting, context, message):
         meeting.is_chair.return_value = True
@@ -628,9 +628,11 @@ class TestCommandDispatcher:
         assert meeting.motion_index is None
         meeting.is_chair.assert_called_once_with("nick")  # message.sender
         meeting.track_event.assert_called_once_with(EventType.ACCEPTED, message, operand="Motion accepted: 3 in favor to 0 opposed")
-        context.send_reply.assert_has_calls(
-            [call("Motion accepted: 3 in favor to 0 opposed"), call("In favor: one, two, three"), call("Opposed: ")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Motion accepted: 3 in favor to 0 opposed"),
+            call("In favor: one, two, three"),
+            call("Opposed: "),
+        ])
 
     def test_close_failed(self, dispatcher, meeting, context, message):
         meeting.is_chair.return_value = True
@@ -648,9 +650,11 @@ class TestCommandDispatcher:
         assert meeting.motion_index is None
         meeting.is_chair.assert_called_once_with("nick")  # message.sender
         meeting.track_event.assert_called_once_with(EventType.FAILED, message, operand="Motion failed: 1 in favor to 2 opposed")
-        context.send_reply.assert_has_calls(
-            [call("Motion failed: 1 in favor to 2 opposed"), call("In favor: three"), call("Opposed: one, two")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Motion failed: 1 in favor to 2 opposed"),
+            call("In favor: three"),
+            call("Opposed: one, two"),
+        ])
 
     def test_close_inconclusive(self, dispatcher, meeting, context, message):
         meeting.is_chair.return_value = True
@@ -671,9 +675,11 @@ class TestCommandDispatcher:
         meeting.track_event.assert_called_once_with(
             EventType.INCONCLUSIVE, message, operand="Motion inconclusive: 2 in favor to 2 opposed"
         )
-        context.send_reply.assert_has_calls(
-            [call("Motion inconclusive: 2 in favor to 2 opposed"), call("In favor: three, four"), call("Opposed: one, two")]
-        )
+        context.send_reply.assert_has_calls([
+            call("Motion inconclusive: 2 in favor to 2 opposed"),
+            call("In favor: three, four"),
+            call("Opposed: one, two"),
+        ])
 
     def test_accepted_as_chair(self, dispatcher, meeting, context, message):
         meeting.is_chair.return_value = True

--- a/src/tests/hcoopmeetbotlogic/test_handler.py
+++ b/src/tests/hcoopmeetbotlogic/test_handler.py
@@ -270,9 +270,7 @@ class TestCommands:
     def test_commands(self, list_commands, send_reply, logger, context):
         list_commands.return_value = ["a", "b", "c"]
         commands(context)
-        send_reply.assert_has_calls(
-            [
-                call(context, "Available commands: a, b, c"),
-                call(context, "See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
-            ]
-        )
+        send_reply.assert_has_calls([
+            call(context, "Available commands: a, b, c"),
+            call(context, "See also: https://hcoop-meetbot.readthedocs.io/en/stable/"),
+        ])


### PR DESCRIPTION
I've been working with the Ruff toolchain for the last year or so at Enveritas.  While I would prefer to have a toolchain that is entirely written in Python for use with Python code, the reality is 1) Ruff is a _lot_ faster, and 2) it's got a lot of momentum in the community.   Plus, it's nice that all of the formatting is integrated together in a single tool, rather than split between black and isort.  The speed difference doesn't make that much of a difference here, but Ruff works pretty well, so I've decided to switch to it.

The code changes are all automated changes, in places where Ruff's formatting is slightly different than black's.

This work was prototyped in [apologies PR #68](https://github.com/pronovic/apologies/pull/68).