### PR TITLE
Remove importlib-metadata dependency in favor of standard library

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Version 0.6.16     unreleased
 	* Add a new `run clean` target to clean up generated data.
 	* Move unit tests from `tests` into `src/tests/hcoopmeetbotlogic`.
 	* Replace black and isort tools with the Ruff formatter.
+	* Remove importlib-metadata dependency in favor of standard library.
 	* Update the jinja2 transitive dependency to address CVE-2025-27516.
 	* Update the requests transitive dependency to address CVE-2024-47081.
 	* Update the urllib3 transitive dependency to address CVE-2025-50181.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,8 +15,8 @@
 
 import os
 import sys
-from pathlib import Path
-from importlib_metadata import metadata
+
+from importlib.metadata import metadata
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/poetry.lock
+++ b/poetry.lock
@@ -460,31 +460,6 @@ files = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.5.0"
-description = "Read metadata from Python packages"
-optional = true
-python-versions = ">=3.8"
-groups = ["main"]
-markers = "extra == \"docs\""
-files = [
-    {file = "importlib_metadata-8.5.0-py3-none-any.whl", hash = "sha256:45e54197d28b7a7f1559e60b95e7c567032b602131fbd588f1497f47880aa68b"},
-    {file = "importlib_metadata-8.5.0.tar.gz", hash = "sha256:71522656f0abace1d072b9e5481a48f07c138e00f079c38c8f883823f9c26bd7"},
-]
-
-[package.dependencies]
-zipp = ">=3.20"
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-perf = ["ipython"]
-test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["pytest-mypy"]
-
-[[package]]
 name = "iniconfig"
 version = "2.0.0"
 description = "brain-dead simple config-ini parsing"
@@ -1296,31 +1271,10 @@ platformdirs = ">=3.9.1,<5"
 docs = ["furo (>=2023.7.26)", "proselint (>=0.13)", "sphinx (>=7.1.2,!=7.3)", "sphinx-argparse (>=0.4)", "sphinxcontrib-towncrier (>=0.2.1a0)", "towncrier (>=23.6)"]
 test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess (>=1)", "flaky (>=3.7)", "packaging (>=23.1)", "pytest (>=7.4)", "pytest-env (>=0.8.2)", "pytest-freezer (>=0.4.8)", "pytest-mock (>=3.11.1)", "pytest-randomly (>=3.12)", "pytest-timeout (>=2.1)", "setuptools (>=68)", "time-machine (>=2.10)"]
 
-[[package]]
-name = "zipp"
-version = "3.21.0"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-optional = true
-python-versions = ">=3.9"
-groups = ["main"]
-markers = "extra == \"docs\""
-files = [
-    {file = "zipp-3.21.0-py3-none-any.whl", hash = "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"},
-    {file = "zipp-3.21.0.tar.gz", hash = "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4"},
-]
-
-[package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1)"]
-cover = ["pytest-cov"]
-doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-enabler = ["pytest-enabler (>=2.2)"]
-test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-ignore-flaky"]
-type = ["pytest-mypy"]
-
 [extras]
-docs = ["importlib-metadata", "sphinx", "sphinx-autoapi"]
+docs = ["sphinx", "sphinx-autoapi"]
 
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "945ccfbaccdbb641364a293a300ad9de2d599e76dc0d79cf904dc10537f3da3c"
+content-hash = "8c36aca17701177c224d37a0d007ef7d434b29648c08646f9c65b20f09992b67"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,6 @@ repository = "https://github.com/pronovic/hcoop-meetbot"
 
 [project.optional-dependencies]
 docs = [
-   "importlib-metadata (>=8.5.0,<9.0.0)",
    "sphinx (>=8.1.3,<9.0.0)",
    "sphinx-autoapi (>=3.3.3,<4.0.0)",
 ]

--- a/src/tests/hcoopmeetbotlogic/test_cli.py
+++ b/src/tests/hcoopmeetbotlogic/test_cli.py
@@ -1,18 +1,15 @@
 # -*- coding: utf-8 -*-
 # vim: set ft=python ts=4 sw=4 expandtab:
 import os
-import sys
 from tempfile import TemporaryDirectory
 from typing import List
 from unittest.mock import ANY, MagicMock, patch
 
-import pytest
 from click.testing import CliRunner, Result
 
 from hcoopmeetbotlogic.cli import meetbot as command
 from hcoopmeetbotlogic.config import OutputFormat
 from hcoopmeetbotlogic.location import Location, Locations
-
 from .testdata import contents
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "fixtures/test_config/valid/HcoopMeetbot.conf")
@@ -36,22 +33,12 @@ class TestCommon:
         result = invoke(["--help"])
         assert result.exit_code == 0
 
-    @pytest.mark.skipif(sys.version_info >= (3, 9), reason="see comments")
-    def test_version(self):
-        # This tests the --version switch, without fully verifying its output.  This test should
-        # succeed on all versions of Python that we support, including older versions that rely
-        # on the importlib-metadata backport package.
-        result = invoke(["--version"])
-        assert result.exit_code == 0
-        assert result.output.startswith("hcoop-meetbot, version")
-
     @patch("importlib.metadata.version")  # this is used underneath by @click.version_option()
-    @pytest.mark.skipif(sys.version_info < (3, 9), reason="see comments")
     def test_version_output(self, version):
         # This tests the --version switch, and fully verifies its output.  It will only succeed on
-        # Python >= 3.9, where importlib.metadata.version exists in the standard library.  We use the
-        # importlib-metadata backport for earlier versions of Python, but for some reason @patch doesn't
-        # work when using the backport package.
+        # Python >= 3.9, where importlib.metadata.version exists in the standard library.  We previously
+        # used the importlib-metadata backport for earlier versions of Python, but that's no longer
+        # necessary.
         version.return_value = "1234"
         result = invoke(["--version"])
         assert result.exit_code == 0


### PR DESCRIPTION
Based on [the docs](https://docs.python.org/3/library/importlib.metadata.html), `importlib.metadata` is "no longer provisional" as of Python 3.10. Looking back at the commit history, I added this dependency back in late 2022, when I was supporting Python 3.8.  I don't need it any more, and I can rely on the standard library instead.