### PR TITLE
Address Ruff linter rule UP031

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -179,7 +179,6 @@ ignore = [
   "FURB101",    # allow old-style open() and read() operations
   "FURB103",    # allow old-style open() and write() operations
   "PTH",        # allow old-style os operations rather than pathlib.Path
-  "UP031",      # allow old-style format specifiers instead of f-strings
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/HcoopMeetbot/plugin.py
+++ b/src/HcoopMeetbot/plugin.py
@@ -47,7 +47,7 @@ class HcoopMeetbot(callbacks.Plugin):
     def __init__(self, irc):
         """Initialize the plugin with our custom configuration."""
         super().__init__(irc)
-        handler.configure(self.log, "%s" % conf.supybot.directories.conf)
+        handler.configure(self.log, f"{conf.supybot.directories.conf}")
 
     def doPrivmsg(self, irc, msg):
         """Capture all messages from supybot."""
@@ -63,7 +63,7 @@ class HcoopMeetbot(callbacks.Plugin):
             network=irc.msg.tags["receivedOn"],
             payload=msg.args[1],
             topic=topic,
-            channel_nicks=["%s" % n for n in users],
+            channel_nicks=[f"{n}" for n in users],
         )
         handler.irc_message(context=context, message=message)
 

--- a/src/HcoopMeetbot/test.py
+++ b/src/HcoopMeetbot/test.py
@@ -35,7 +35,7 @@ def _inbound(payload: str):
         nick=NICK,
         channel=CHANNEL,
         network=NETWORK,
-        payload="%s%s" % (PREFIX, payload),
+        payload=f"{PREFIX}{payload}",
         topic="",
         channel_nicks=[NICK],
     )
@@ -43,7 +43,7 @@ def _inbound(payload: str):
 
 def _outbound():
     """Generate an expected outbound message returned to the caller based on the _stub() call"""
-    return Message(id=ID, timestamp=TIMESTAMP, nick=NICK, channel=CHANNEL, network=NETWORK, payload="%s: Hello" % NICK)
+    return Message(id=ID, timestamp=TIMESTAMP, nick=NICK, channel=CHANNEL, network=NETWORK, payload=f"{NICK}: Hello")
 
 
 class HcoopMeetbotTestCase(ChannelPluginTestCase):

--- a/src/hcoopmeetbotlogic/cli.py
+++ b/src/hcoopmeetbotlogic/cli.py
@@ -60,11 +60,11 @@ def regenerate(config_path: str, raw_log: str, output_dir: str) -> None:
     will be generated using the exact same prefix as the raw log file itself.
     """
     if not os.path.isfile(config_path):
-        raise click.UsageError("Could not find config: %s" % config_path)
+        raise click.UsageError(f"Could not find config: {config_path}")
     if not os.path.isfile(raw_log):
-        raise click.UsageError("Could not find raw log: %s" % raw_log)
+        raise click.UsageError(f"Could not find raw log: {raw_log}")
     if not os.path.isdir(output_dir):
-        raise click.UsageError("Could not find output dir: %s" % output_dir)
+        raise click.UsageError(f"Could not find output dir: {output_dir}")
     config = load_config(None, config_path)
     prefix = derive_prefix(raw_log)
     with open(raw_log, encoding="utf-8") as fp:

--- a/src/hcoopmeetbotlogic/command.py
+++ b/src/hcoopmeetbotlogic/command.py
@@ -55,10 +55,10 @@ class CommandDispatcher:
             meeting.track_event(EventType.START_MEETING, message)
             meeting.original_topic = context.get_topic()
             self._set_channel_topic(meeting, context)
-            context.send_reply("Meeting started at %s" % self._formatdate(meeting.start_time))
-            context.send_reply("Current chairs: %s" % ", ".join(meeting.chairs))
+            context.send_reply(f"Meeting started at {self._formatdate(meeting.start_time)}")
+            context.send_reply("Current chairs: {}".format(", ".join(meeting.chairs)))
             context.send_reply("Useful commands: #action #info #idea #link #topic #motion #vote #close #endmeeting")
-            context.send_reply("See also: %s" % DOCS)
+            context.send_reply(f"See also: {DOCS}")
             context.send_reply("Participants should now identify themselves with '#here' or with an alias like '#here FirstLast'")
 
     def do_endmeeting(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
@@ -69,10 +69,10 @@ class CommandDispatcher:
             meeting.active = False
             self._set_channel_topic(meeting, context)
             locations = write_meeting(config=config(), meeting=meeting)
-            context.send_reply("Meeting ended at %s" % self._formatdate(meeting.end_time))
-            context.send_reply("Raw log: %s" % locations.raw_log.url)
-            context.send_reply("Formatted log: %s" % locations.formatted_log.url)
-            context.send_reply("Minutes: %s" % locations.formatted_minutes.url)
+            context.send_reply(f"Meeting ended at {self._formatdate(meeting.end_time)}")
+            context.send_reply(f"Raw log: {locations.raw_log.url}")
+            context.send_reply(f"Formatted log: {locations.formatted_log.url}")
+            context.send_reply(f"Minutes: {locations.formatted_minutes.url}")
             deactivate_meeting(meeting, retain=True)
 
     def do_save(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
@@ -81,9 +81,9 @@ class CommandDispatcher:
             meeting.track_event(EventType.SAVE_MEETING, message)
             locations = write_meeting(config=config(), meeting=meeting)
             context.send_reply("Meeting saved")
-            context.send_reply("Raw log: %s" % locations.raw_log.url)
-            context.send_reply("Formatted log: %s" % locations.formatted_log.url)
-            context.send_reply("Minutes: %s" % locations.formatted_minutes.url)
+            context.send_reply(f"Raw log: {locations.raw_log.url}")
+            context.send_reply(f"Formatted log: {locations.formatted_log.url}")
+            context.send_reply(f"Minutes: {locations.formatted_minutes.url}")
 
     def do_topic(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Set a new topic in the channel."""
@@ -100,7 +100,7 @@ class CommandDispatcher:
                 meeting.track_event(EventType.ADD_CHAIR, message, operand=chairs)
                 for nick in chairs:
                     meeting.add_chair(nick, primary=False)
-                context.send_reply("Current chairs: %s" % ", ".join(meeting.chairs))
+                context.send_reply("Current chairs: {}".format(", ".join(meeting.chairs)))
 
     def do_unchair(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Remove a chair from the meeting."""
@@ -110,7 +110,7 @@ class CommandDispatcher:
                 meeting.track_event(EventType.REMOVE_CHAIR, message, operand=chairs)
                 for nick in chairs:
                     meeting.remove_chair(nick)
-                context.send_reply("Current chairs: %s" % ", ".join(meeting.chairs))
+                context.send_reply("Current chairs: {}".format(", ".join(meeting.chairs)))
 
     def do_here(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Document attendance and optionally associate a nick with an alias, for use with actions."""
@@ -125,7 +125,7 @@ class CommandDispatcher:
             meeting.track_event(EventType.TRACK_NICK, message, operand=nicks)
             for nick in nicks:
                 meeting.track_nick(nick, messages=0)
-            context.send_reply("Current nicks: %s" % ", ".join(meeting.nicks.keys()))
+            context.send_reply("Current nicks: {}".format(", ".join(meeting.nicks.keys())))
 
     def do_undo(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Remove the most recent item from the minutes."""
@@ -133,14 +133,14 @@ class CommandDispatcher:
             removed = meeting.pop_event()
             if removed:
                 meeting.track_event(EventType.UNDO, message, operand=removed.id)
-                context.send_reply("Removed event: %s" % removed.display_name())
+                context.send_reply(f"Removed event: {removed.display_name()}")
 
     def do_meetingname(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Set the meeting name, which defaults to the channel name."""
         if meeting.is_chair(message.sender):
             meeting.track_event(EventType.MEETING_NAME, message, operand=operand)
             meeting.name = operand
-            context.send_reply("Meeting name set to: %s" % operand)
+            context.send_reply(f"Meeting name set to: {operand}")
 
     def do_motion(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Open a motion."""
@@ -170,19 +170,19 @@ class CommandDispatcher:
                 meeting.vote_in_progress = False
                 meeting.motion_index = None
                 if len(in_favor) > len(opposed):
-                    result = "Motion accepted: %d in favor to %d opposed" % (len(in_favor), len(opposed))
+                    result = f"Motion accepted: {len(in_favor)} in favor to {len(opposed)} opposed"
                     meeting.track_event(EventType.ACCEPTED, message, operand=result)
                     context.send_reply(result)
                 elif len(in_favor) < len(opposed):
-                    result = "Motion failed: %d in favor to %d opposed" % (len(in_favor), len(opposed))
+                    result = f"Motion failed: {len(in_favor)} in favor to {len(opposed)} opposed"
                     meeting.track_event(EventType.FAILED, message, operand=result)
                     context.send_reply(result)
                 elif len(in_favor) == len(opposed):
-                    result = "Motion inconclusive: %d in favor to %d opposed" % (len(in_favor), len(opposed))
+                    result = f"Motion inconclusive: {len(in_favor)} in favor to {len(opposed)} opposed"
                     meeting.track_event(EventType.INCONCLUSIVE, message, operand=result)
                     context.send_reply(result)
-                context.send_reply("In favor: %s" % ", ".join(in_favor))
-                context.send_reply("Opposed: %s" % ", ".join(opposed))
+                context.send_reply("In favor: {}".format(", ".join(in_favor)))
+                context.send_reply("Opposed: {}".format(", ".join(opposed)))
 
     def do_accepted(self, meeting: Meeting, context: Context, operation: str, operand: str, message: TrackedMessage) -> None:
         """Indicate that a motion has been accepted."""
@@ -253,7 +253,7 @@ class CommandDispatcher:
         if config().use_channel_topic:
             if meeting.active:
                 if meeting.current_topic:
-                    context.set_topic("%s" % meeting.current_topic)
+                    context.set_topic(f"{meeting.current_topic}")
                 else:
                     context.set_topic("Meeting Active")
             else:
@@ -278,10 +278,10 @@ def dispatch(meeting: Meeting, context: Context, message: TrackedMessage) -> Non
     if operation_match:
         operation = operation_match.group(_OPERATION_GROUP).lower().strip()
         operand = operation_match.group(_OPERAND_GROUP).strip()
-        if hasattr(_DISPATCHER, "%s%s" % (_METHOD_PREFIX, operation)):
-            getattr(_DISPATCHER, "%s%s" % (_METHOD_PREFIX, operation))(meeting, context, operation, operand, message)
+        if hasattr(_DISPATCHER, f"{_METHOD_PREFIX}{operation}"):
+            getattr(_DISPATCHER, f"{_METHOD_PREFIX}{operation}")(meeting, context, operation, operand, message)
         else:
-            context.send_reply("Unknown command: #%s" % operation)
+            context.send_reply(f"Unknown command: #{operation}")
     elif url_match:
         # as a special case, turns messages that start with a URL into a link operation
         operation = "link"

--- a/src/hcoopmeetbotlogic/handler.py
+++ b/src/hcoopmeetbotlogic/handler.py
@@ -81,7 +81,7 @@ def outbound_message(context: Context, message: Message) -> None:
 def meetversion(context: Context) -> None:
     """Reply with a string describing the version of the plugin."""
     logger().debug("Handled 'meetversion'")
-    _send_reply(context, "HCoop Meetbot v%s (%s)" % (VERSION, DATE))
+    _send_reply(context, f"HCoop Meetbot v{VERSION} ({DATE})")
 
 
 def listmeetings(context: Context) -> None:
@@ -110,7 +110,7 @@ def savemeetings(context: Context) -> None:
     else:
         for meeting in meetings:
             write_meeting(config=config(), meeting=meeting)
-        reply = "Saved %d meeting%s" % (len(meetings), "s" if len(meetings) > 1 else "")
+        reply = f"Saved {len(meetings)} meeting{'s' if len(meetings) > 1 else ''}"
     _send_reply(context, reply)
 
 
@@ -127,10 +127,10 @@ def addchair(context: Context, channel: str, network: str, nick: str) -> None:
     logger().debug("Handled 'addchair' for %s/%s nick=%s", channel, network, nick)
     meeting = get_meeting(channel, network)
     if not meeting:
-        reply = "Meeting not found for %s/%s" % (channel, network)
+        reply = f"Meeting not found for {channel}/{network}"
     else:
         meeting.add_chair(nick, primary=True)
-        reply = "%s is now the primary chair for %s" % (meeting.chair, meeting.display_name())
+        reply = f"{meeting.chair} is now the primary chair for {meeting.display_name()}"
     _send_reply(context, reply)
 
 
@@ -150,12 +150,12 @@ def deletemeeting(context: Context, channel: str, network: str, *, save: bool) -
     logger().debug("Handled 'deletemeeting' for %s/%s save=%s", channel, network, save)
     meeting = get_meeting(channel, network)
     if not meeting:
-        reply = "Meeting not found for %s/%s" % (channel, network)
+        reply = f"Meeting not found for {channel}/{network}"
     else:
         if save:
             write_meeting(config=config(), meeting=meeting)
         deactivate_meeting(meeting, retain=False)
-        reply = "Meeting %s has been deleted%s" % (meeting.display_name(), " (saved first)" if save else "")
+        reply = "Meeting {} has been deleted{}".format(meeting.display_name(), " (saved first)" if save else "")
     _send_reply(context, reply)
 
 
@@ -180,5 +180,5 @@ def commands(context: Context) -> None:
         context(Context): Context for a message or command
     """
     logger().debug("Handled 'commands'")
-    _send_reply(context, "Available commands: %s" % ", ".join(list_commands()))
-    _send_reply(context, "See also: %s" % DOCS)
+    _send_reply(context, "Available commands: {}".format(", ".join(list_commands())))
+    _send_reply(context, f"See also: {DOCS}")

--- a/src/hcoopmeetbotlogic/location.py
+++ b/src/hcoopmeetbotlogic/location.py
@@ -47,7 +47,7 @@ def _file_prefix(config: Config, meeting: Meeting) -> str:
 def _abs_path(config: Config, file_prefix: str, suffix: str, output_dir: str | None) -> str:
     """Build an absolute path for a file in the log directory, preventing path traversal."""
     log_dir = Path(output_dir) if output_dir else Path(config.log_dir)
-    target = "%s%s" % (file_prefix, suffix)  # might include slashes and other traversal like ".."
+    target = f"{file_prefix}{suffix}"  # might include slashes and other traversal like ".."
     safe = log_dir.joinpath(target).resolve().relative_to(log_dir.resolve())  # blows up if outside of log dir
     return log_dir.joinpath(safe).absolute().as_posix()
 
@@ -55,7 +55,7 @@ def _abs_path(config: Config, file_prefix: str, suffix: str, output_dir: str | N
 def _url(config: Config, file_prefix: str, suffix: str) -> str:
     """Build a URL for a file in the log directory."""
     # We don't worry about path traversal here, because it's up to the webserver to decide what is allowed
-    return "%s/%s%s" % (config.url_prefix, file_prefix, suffix)
+    return f"{config.url_prefix}/{file_prefix}{suffix}"
 
 
 def _location(config: Config, file_prefix: str, suffix: str, output_dir: str | None) -> Location:
@@ -90,4 +90,4 @@ def derive_locations(config: Config, meeting: Meeting, prefix: str | None = None
             formatted_log=_location(config, file_prefix, HTML_LOG_EXTENSION, output_dir),
             formatted_minutes=_location(config, file_prefix, HTML_MINUTES_EXTENSION, output_dir),
         )
-    raise ValueError("Unsupported output format: %s" % config.output_format)
+    raise ValueError(f"Unsupported output format: {config.output_format}")

--- a/src/hcoopmeetbotlogic/meeting.py
+++ b/src/hcoopmeetbotlogic/meeting.py
@@ -87,7 +87,7 @@ class TrackedMessage:
 
     def display_name(self) -> str:
         """Get the message display name."""
-        return "%s@%s" % (self.id, formatdate(self.timestamp))
+        return f"{self.id}@{formatdate(self.timestamp)}"
 
 
 @frozen
@@ -122,7 +122,7 @@ class TrackedEvent:
 
     def display_name(self) -> str:
         """Get the event display name."""
-        return "%s@%s" % (self.id, formatdate(self.timestamp))
+        return f"{self.id}@{formatdate(self.timestamp)}"
 
 
 @define(slots=False)
@@ -204,7 +204,7 @@ class Meeting:
     @staticmethod
     def meeting_key(channel: str, network: str) -> str:
         """Build the dict key for a network and channel."""
-        return "%s/%s" % (channel, network)
+        return f"{channel}/{network}"
 
     def to_json(self) -> str:
         """Serialize a meeting to JSON."""
@@ -220,7 +220,7 @@ class Meeting:
 
     def display_name(self) -> str:
         """Get the meeting display name."""
-        return "%s/%s@%s" % (self.channel, self.network, formatdate(self.start_time))
+        return f"{self.channel}/{self.network}@{formatdate(self.start_time)}"
 
     def add_chair(self, nick: str, *, primary: bool = True) -> None:
         """Add a chair to a meeting, potentially making it the primary chair."""

--- a/src/tests/hcoopmeetbotlogic/test_cli.py
+++ b/src/tests/hcoopmeetbotlogic/test_cli.py
@@ -12,7 +12,7 @@ from tests.hcoopmeetbotlogic.testdata import contents
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "fixtures/test_config/valid/HcoopMeetbot.conf")
 RAW_LOG_PREFIX = "2022-06-04"
-RAW_LOG = os.path.join(os.path.dirname(__file__), "fixtures/test_cli/%s.log.json" % RAW_LOG_PREFIX)
+RAW_LOG = os.path.join(os.path.dirname(__file__), f"fixtures/test_cli/{RAW_LOG_PREFIX}.log.json")
 EXPECTED_LOG = os.path.join(os.path.dirname(__file__), "fixtures/test_writer/log.html")
 EXPECTED_MINUTES = os.path.join(os.path.dirname(__file__), "fixtures/test_writer/minutes.html")
 

--- a/src/tests/hcoopmeetbotlogic/test_command.py
+++ b/src/tests/hcoopmeetbotlogic/test_command.py
@@ -74,7 +74,7 @@ class TestFunctions:
     )
     @patch("hcoopmeetbotlogic.command._DISPATCHER")
     def test_dispatch_valid_link(self, dispatcher, protocol):
-        url = "%s://whatever" % protocol
+        url = f"{protocol}://whatever"
         run_dispatch(url, "link", url, dispatcher.do_link)
 
     @pytest.mark.parametrize(
@@ -86,7 +86,7 @@ class TestFunctions:
     )
     @patch("hcoopmeetbotlogic.command._DISPATCHER")
     def test_dispatch_invalid_link(self, dispatcher, protocol):
-        url = "%s://whatever" % protocol
+        url = f"{protocol}://whatever"
         meeting = MagicMock(channel="#channel")
         context = MagicMock()
         message = MagicMock(payload=url)

--- a/src/tests/hcoopmeetbotlogic/test_writer.py
+++ b/src/tests/hcoopmeetbotlogic/test_writer.py
@@ -32,19 +32,19 @@ class TestLogMessage:
         message.action = False
         message.payload = "payload"
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
-        assert "%s" % result.content == "<span><span>payload</span></span>"
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.content}" == "<span><span>payload</span></span>"
 
     def test_action_payload(self, config, message):
         message.action = True
         message.payload = "payload"
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nka">&lt;nick&gt;</span>'
-        assert "%s" % result.content == '<span class="ac"><span><span>payload</span></span></span>'
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nka">&lt;nick&gt;</span>'
+        assert f"{result.content}" == '<span class="ac"><span><span>payload</span></span></span>'
 
     @pytest.mark.parametrize(
         "payload,operation,operand",
@@ -59,16 +59,15 @@ class TestLogMessage:
         message.action = False
         message.payload = payload
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
         assert (
-            "%s" % result.content
-            == '<span><span class="topic">'
-            + "%s" % operation
-            + ' </span><span class="topicline"><span><span>'
-            + "%s" % operand
-            + "</span></span></span></span>"
+            f"{result.content}" == '<span><span class="topic">'
+            f"{operation}"
+            ' </span><span class="topicline"><span><span>'
+            f"{operand}"
+            "</span></span></span></span>"
         )
 
     @pytest.mark.parametrize(
@@ -84,37 +83,34 @@ class TestLogMessage:
         message.action = False
         message.payload = payload
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
         assert (
-            "%s" % result.content
-            == '<span><span class="cmd">'
-            + "%s" % operation
-            + ' </span><span class="cmdline"><span><span>'
-            + "%s" % operand
-            + "</span></span></span></span>"
+            f"{result.content}" == '<span><span class="cmd">'
+            f"{operation}"
+            ' </span><span class="cmdline"><span><span>'
+            f"{operand}"
+            "</span></span></span></span>"
         )
 
     def test_highlights(self, config, message):
         message.action = False
         message.payload = "nick: this is some stuff: yeah that stuff"
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
-        assert (
-            "%s" % result.content == '<span><span class="hi">nick:</span><span> this is some stuff: yeah that stuff</span></span>'
-        )
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.content}" == '<span><span class="hi">nick:</span><span> this is some stuff: yeah that stuff</span></span>'
 
     def test_url(self, config, message):
         message.action = False
         message.payload = "http://whatever this should not be highlighted"
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
-        assert "%s" % result.content == "<span><span>http://whatever this should not be highlighted</span></span>"
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.content}" == "<span><span>http://whatever this should not be highlighted</span></span>"
 
     # we can generally expect Genshi to handle this stuff, so this is a spot-check
     # examples from: https://owasp.org/www-community/attacks/xss/
@@ -139,10 +135,10 @@ class TestLogMessage:
         message.action = False
         message.payload = payload
         result = _LogMessage.for_message(config, message)
-        assert "%s" % result.id == '<a name="id"/>'
-        assert "%s" % result.timestamp == '<span class="tm">13:14:00</span>'
-        assert "%s" % result.nick == '<span class="nk">&lt;nick&gt;</span>'
-        assert "%s" % result.content == "<span><span>" + "%s" % expected + "</span></span>"
+        assert f"{result.id}" == '<a name="id"/>'
+        assert f"{result.timestamp}" == '<span class="tm">13:14:00</span>'
+        assert f"{result.nick}" == '<span class="nk">&lt;nick&gt;</span>'
+        assert f"{result.content}" == "<span><span>" + f"{expected}" + "</span></span>"
 
 
 class TestRendering:
@@ -194,40 +190,40 @@ class TestAliasMatcher:
         no_match = []
 
         # These should be considered a match because the identifier is found unambiguously
-        match.append("%s" % identifier)
-        match.append("%s got assigned a task" % identifier)
-        match.append("assign that to %s please" % identifier)
-        match.append("that task goes to %s" % identifier)
-        match.append("hey %s: please take care of that" % identifier)
-        match.append("an action item (%s)" % identifier)
-        match.append("(%s) an action item" % identifier)
+        match.append(f"{identifier}")
+        match.append(f"{identifier} got assigned a task")
+        match.append(f"assign that to {identifier} please")
+        match.append(f"that task goes to {identifier}")
+        match.append(f"hey {identifier}: please take care of that")
+        match.append(f"an action item ({identifier})")
+        match.append(f"({identifier}) an action item")
 
         # These should NOT be considered a match because the identifier has a prefix
-        no_match.append("prefix%s" % identifier)
-        no_match.append("prefix%s got assigned a task" % identifier)
-        no_match.append("assign that to prefix%s please" % identifier)
-        no_match.append("that task goes to prefix%s" % identifier)
-        no_match.append("hey prefix%s: please take care of that" % identifier)
-        no_match.append("an action item (prefix%s)" % identifier)
-        no_match.append("(prefix%s) an action item" % identifier)
+        no_match.append(f"prefix{identifier}")
+        no_match.append(f"prefix{identifier} got assigned a task")
+        no_match.append(f"assign that to prefix{identifier} please")
+        no_match.append(f"that task goes to prefix{identifier}")
+        no_match.append(f"hey prefix{identifier}: please take care of that")
+        no_match.append(f"an action item (prefix{identifier})")
+        no_match.append(f"(prefix{identifier}) an action item")
 
         # These should NOT be considered a match because the identifier has a suffix
-        no_match.append("%ssuffix" % identifier)
-        no_match.append("%ssuffix got assigned a task" % identifier)
-        no_match.append("assign that to %ssuffix please" % identifier)
-        no_match.append("that task goes to %ssuffix" % identifier)
-        no_match.append("hey %ssuffix: please take care of that" % identifier)
-        no_match.append("an action item (%ssuffix)" % identifier)
-        no_match.append("(%ssuffix) an action item" % identifier)
+        no_match.append(f"{identifier}suffix")
+        no_match.append(f"{identifier}suffix got assigned a task")
+        no_match.append(f"assign that to {identifier}suffix please")
+        no_match.append(f"that task goes to {identifier}suffix")
+        no_match.append(f"hey {identifier}suffix: please take care of that")
+        no_match.append(f"an action item ({identifier}suffix)")
+        no_match.append(f"({identifier}suffix) an action item")
 
         # These should NOT be considered a match because the identifier is embedded in another string
-        no_match.append("prefix%ssuffix" % identifier)
-        no_match.append("prefix%ssuffix got assigned a task" % identifier)
-        no_match.append("assign that to prefix%ssuffix please" % identifier)
-        no_match.append("that task goes to prefix%ssuffix" % identifier)
-        no_match.append("hey prefix%ssuffix: please take care of that" % identifier)
-        no_match.append("an action item (prefix%ssuffix)" % identifier)
-        no_match.append("(prefix%ssuffix) an action item" % identifier)
+        no_match.append(f"prefix{identifier}suffix")
+        no_match.append(f"prefix{identifier}suffix got assigned a task")
+        no_match.append(f"assign that to prefix{identifier}suffix please")
+        no_match.append(f"that task goes to prefix{identifier}suffix")
+        no_match.append(f"hey prefix{identifier}suffix: please take care of that")
+        no_match.append(f"an action item (prefix{identifier}suffix)")
+        no_match.append(f"(prefix{identifier}suffix) an action item")
 
         nick_matcher = _AliasMatcher(identifier, None)  # checks matching for nick
         alias_matcher = _AliasMatcher("bogus", identifier)  # checks matching for alias, since nick will never match
@@ -235,13 +231,13 @@ class TestAliasMatcher:
         for message in match:
             for testcase in [message, message.upper(), message.lower(), message.title()]:  # nicks/aliases are not case-sensitive
                 if not nick_matcher.matches(testcase):
-                    pytest.fail("nick '%s' not found in message '%s'" % (identifier, testcase))
+                    pytest.fail(f"nick '{identifier}' not found in message '{testcase}'")
                 if not alias_matcher.matches(testcase):
-                    pytest.fail("alias '%s' not found in message '%s'" % (identifier, testcase))
+                    pytest.fail(f"alias '{identifier}' not found in message '{testcase}'")
 
         for message in no_match:
             for testcase in [message, message.upper(), message.lower(), message.title()]:  # nicks/aliases are not case-sensitive
                 if nick_matcher.matches(testcase):
-                    pytest.fail("nick '%s' incorrectly found in message '%s'" % (identifier, testcase))
+                    pytest.fail(f"nick '{identifier}' incorrectly found in message '{testcase}'")
                 if alias_matcher.matches(testcase):
-                    pytest.fail("alias '%s' incorrectly found in message '%s'" % (identifier, testcase))
+                    pytest.fail(f"alias '{identifier}' incorrectly found in message '{testcase}'")

--- a/src/tests/hcoopmeetbotlogic/testdata.py
+++ b/src/tests/hcoopmeetbotlogic/testdata.py
@@ -22,7 +22,7 @@ def time(seconds: int) -> datetime:
 
 def message(identifier: int, nick: str, payload: str, seconds: int) -> Message:
     """Generate a mocked message with some values"""
-    return MagicMock(id="id-%d" % identifier, nick=nick, payload=payload, timestamp=time(seconds))
+    return MagicMock(id=f"id-{identifier}", nick=nick, payload=payload, timestamp=time(seconds))
 
 
 def sample_meeting() -> Meeting:


### PR DESCRIPTION
Follow-up to PR #59.  This addresses Ruff linter rule UP031, by converting old-style format specifiers to f-strings instead.