### PR TITLE
Fix pytest-testdox output in GHA Windows runner

### DIFF
--- a/.run/commands/pytest.sh
+++ b/.run/commands/pytest.sh
@@ -33,20 +33,15 @@ command_pytest() {
 
    shift $((OPTIND -1))  # pop off the options consumed by getopts
 
-   color=""
-   if [ "$GITHUB_ACTIONS" == "true" ] && [ "$RUNNER_OS" == "Windows" ]; then
-      color="--color no"  # color messes up the terminal on Windows in GHA
-   fi
-
    if [ $coverage == "yes" ]; then
-      run_command uvrun pytest --cov=. --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --cov=. --testdox --force-testdox $tests
       run_command uvrun coverage lcov -o .coverage.lcov
       if [ $html == "yes" ]; then
          run_command uvrun coverage html -d .htmlcov
          run_command openfile .htmlcov/index.html
       fi
    else
-      run_command uvrun pytest --testdox --force-testdox $color $tests
+      PYTHONUTF8=1 run_command uvrun pytest --testdox --force-testdox $tests
    fi
 }
 

--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,7 @@ Version 0.8.2     unreleased
 	* Upgrade to Pytest v9 for new TOML syntax, strict mode, and Dependabot.
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
-	* Fix python-testdox output in GHA Windows runner.
+	* Fix pytest-testdox output in GHA Windows runner.
 
 Version 0.8.1     16 Nov 2025
 

--- a/Changelog
+++ b/Changelog
@@ -4,7 +4,6 @@ Version 0.8.2     unreleased
 	* Upgrade to Pytest v9 for new TOML syntax, strict mode, and Dependabot.
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
-	* Fix pytest-testdox output in GHA Windows runner.
 
 Version 0.8.1     16 Nov 2025
 

--- a/Changelog
+++ b/Changelog
@@ -4,6 +4,7 @@ Version 0.8.2     unreleased
 	* Upgrade to Pytest v9 for new TOML syntax, strict mode, and Dependabot.
 	* Add support for Visual Studio Code as an IDE.
 	* Use pytest-cov for test coverage, for more consistency.
+	* Fix python-testdox output in GHA Windows runner.
 
 Version 0.8.1     16 Nov 2025
 


### PR DESCRIPTION
Fix pytest-testdox output for unit test suite in GitHub Actions when using Windows runners.  Based on a prototype from [apologies PR #84](https://github.com/pronovic/apologies/pull/84) (see that PR for more details).  This repo doesn't actually exhibit this problem, because it doesn't run tests using a Windows runner, but the change is pulled in anyway as a part of the run script framework.